### PR TITLE
feat: additional GPOS lookups parsers

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -477,6 +477,74 @@ Parser.prototype.parseCoverage = function() {
     throw new Error('0x' + startOffset.toString(16) + ': Coverage format must be 1 or 2.');
 };
 
+/**
+ * Parse a BaseArray Table in GPOS table
+ * https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/gpos#lookup-type-4-mark-to-base-attachment-positioning-subtable
+ * 
+ * @param {Number} marksClassCount 
+ * @returns {Array}
+ */
+Parser.prototype.parseBaseArray = function(marksClassCount) {
+    const count = this.parseUShort();
+    return this.parseList(count, Parser.list(
+        marksClassCount, 
+        Parser.pointer(Parser.anchor)
+    ));
+};
+
+/**
+ * Parse a MarkArray Table in GPOS table
+ * https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/gpos_delta#mark-array-table
+ * 
+ * @returns {Array}
+ */
+Parser.prototype.parseMarkArray = function() {
+    const count = this.parseUShort();
+    return this.parseRecordList(count, {
+        class: Parser.uShort,
+        attachmentPoint: Parser.pointer(Parser.anchor)
+    });
+};
+
+/**
+ * Parse a an anchor definition Table in GPOS table
+ * https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/gpos_delta#anchor-tables
+ * 
+ * @returns {Object} Anchor object representing format type
+ */
+Parser.prototype.parseAnchorPoint = function() {
+    const startOffset = this.offset + this.relativeOffset;
+    const format = this.parseUShort();
+    switch(format) {
+        case 1:
+            return {
+                format,
+                xCoordinate: this.parseShort(),
+                yCoordinate: this.parseShort()
+            };
+        case 2:
+            return {
+                format,
+                xCoordinate: this.parseShort(),
+                yCoordinate: this.parseShort(),
+                anchorPoint: this.parseUShort()
+            };
+
+        // TODO: Add a support Device offsets
+        // https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/gpos_delta#anchor-table-format-3-design-units-plus-device-or-variationindex-tables
+        case 3:
+            return {
+                format,
+                xCoordinate: this.parseShort(),
+                yCoordinate: this.parseShort(),
+                xDevice: 0x00, 
+                yDevice: 0x00,
+            };
+    }
+
+    throw new Error('0x' + startOffset.toString(16) + ': Anchor format must be 1, 2 or 3.');
+};
+
 // Parse a Class Definition Table in a GSUB, GPOS or GDEF table.
 // https://www.microsoft.com/typography/OTSPEC/chapter2.htm
 Parser.prototype.parseClassDef = function() {
@@ -548,6 +616,7 @@ Parser.uLong = Parser.offset32 = Parser.prototype.parseULong;
 Parser.uLongList = Parser.prototype.parseULongList;
 Parser.struct = Parser.prototype.parseStruct;
 Parser.coverage = Parser.prototype.parseCoverage;
+Parser.anchor = Parser.prototype.parseAnchorPoint;
 Parser.classDef = Parser.prototype.parseClassDef;
 
 ///// Script, Feature, Lookup lists ///////////////////////////////////////////////

--- a/src/tables/gpos.js
+++ b/src/tables/gpos.js
@@ -77,12 +77,47 @@ subtableParsers[2] = function parseLookup2() {
 };
 
 subtableParsers[3] = function parseLookup3() { return { error: 'GPOS Lookup 3 not supported' }; };
-subtableParsers[4] = function parseLookup4() { return { error: 'GPOS Lookup 4 not supported' }; };
+
+// https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-4-mark-to-base-attachment-positioning-subtable
+subtableParsers[4] = function parseLookup4() {
+    const start = this.offset + this.relativeOffset;
+    const posFormat = this.parseUShort();
+    check.assert(posFormat === 1, '0x' + start.toString(16) + ': GPOS lookup type 4 format must be 1.');
+    const markCoverage = this.parsePointer(Parser.coverage);
+    const baseCoverage = this.parsePointer(Parser.coverage);
+    const markClassCount = this.parseUShort();
+    const markArray = this.parsePointer(function() {
+        return this.parseMarkArray();
+    });
+    const baseArray = this.parsePointer(function() {
+        return this.parseBaseArray(markClassCount);
+    });
+    return {
+        posFormat,
+        markCoverage,
+        baseCoverage,
+        markArray,
+        baseArray
+    };
+};
+
 subtableParsers[5] = function parseLookup5() { return { error: 'GPOS Lookup 5 not supported' }; };
 subtableParsers[6] = function parseLookup6() { return { error: 'GPOS Lookup 6 not supported' }; };
 subtableParsers[7] = function parseLookup7() { return { error: 'GPOS Lookup 7 not supported' }; };
 subtableParsers[8] = function parseLookup8() { return { error: 'GPOS Lookup 8 not supported' }; };
-subtableParsers[9] = function parseLookup9() { return { error: 'GPOS Lookup 9 not supported' }; };
+
+// https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning
+subtableParsers[9] = function parseLookup9() {
+    const start = this.offset + this.relativeOffset;
+    const posFormat = this.parseUShort();
+    check.assert(posFormat === 1, '0x' + start.toString(16) + ': GPOS lookup type 9 format must be 1.');
+    const extensionLookupType = this.parseUShort();
+    return {
+        posFormat,
+        extensionLookupType,
+        extension: this.parsePointer32(subtableParsers[extensionLookupType])
+    };
+};
 
 // https://docs.microsoft.com/en-us/typography/opentype/spec/gpos
 function parseGposTable(data, start) {

--- a/test/parse.js
+++ b/test/parse.js
@@ -106,6 +106,140 @@ describe('parse.js', function() {
         });
     });
 
+    describe('parseMarkArray', () => {
+        it('should parse a Mark Array table', () => {
+            const data = '0003 ' + // marksCount
+            ' 0000  000E ' + // mark1 class and its anchor offset
+            ' 0001  001A ' + // mark2 class and its anchor offset
+            ' 0000  0014 ' + // mark3 class and its anchor offset
+            ' 0001 00BD 012D ' +   
+            ' 0001 00DD 012E ' +
+            ' 0002 00DF FED1 0001';
+
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseMarkArray(), [{
+                class: 0,
+                attachmentPoint: {
+                    format: 1,
+                    xCoordinate: 189,
+                    yCoordinate: 301
+                }
+            }, {
+                class: 1,
+                attachmentPoint: {
+                    format: 2,
+                    xCoordinate: 223,
+                    yCoordinate: -303,
+                    anchorPoint: 1
+                }
+            },{
+                class: 0,
+                attachmentPoint: {
+                    format: 1,
+                    xCoordinate: 221,
+                    yCoordinate: 302,
+
+                }
+            }]);
+
+            assert.equal(p.relativeOffset, 14);
+        });
+    });
+
+    describe('parseBaseArray', () => {
+        it('should parse a Base Array table', () => {
+            const data = '0002 ' + // baseCount
+            ' 000E 0014 001E' + // baseRecord1 anchor offsets foreach class anchor point
+            ' 0014 000E 001E' + // baseRecord2 anchor offsets foreach class anchor point
+            ' 0001 00BD 012D ' +    // 
+            ' 0003 00BD 012D 0000 0000 ' +
+            ' 0002 00DF FED1 0001';
+
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseBaseArray(3), [
+                [
+                    {
+                        format: 1,
+                        xCoordinate: 189,
+                        yCoordinate: 301
+                    },
+                    {
+                        format: 3,
+                        xCoordinate: 189,
+                        yCoordinate: 301,
+                        xDevice: 0,
+                        yDevice: 0
+                    },
+                    {
+                        format: 2,
+                        xCoordinate: 223,
+                        yCoordinate: -303,
+                        anchorPoint: 1
+                    }
+                ],
+                [
+                    
+                    {
+                        format: 3,
+                        xCoordinate: 189,
+                        yCoordinate: 301,
+                        xDevice: 0,
+                        yDevice: 0
+                    },
+                    {
+                        format: 1,
+                        xCoordinate: 189,
+                        yCoordinate: 301
+                    },
+                    {
+                        format: 2,
+                        xCoordinate: 223,
+                        yCoordinate: -303,
+                        anchorPoint: 1
+                    }
+                ]
+            ]);
+
+            assert.equal(p.relativeOffset, 14);
+
+        });
+    });
+
+    describe('parseAnchorPoint', () => {
+        it('should parse a AnchorTableFormat1 table', () => {
+            const data =' 0001 00BD 012D';
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseAnchorPoint(), {
+                format: 1,
+                xCoordinate: 189,
+                yCoordinate: 301,
+            });
+        });
+
+        it('should parse a AnchorTableFormat2 table', () => {
+            const data =' 0002 00DF FED1 0003';
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseAnchorPoint(), {
+                format: 2,
+                xCoordinate: 223,
+                yCoordinate: -303,
+                anchorPoint: 3
+            });
+        });
+
+        it('should parse a AnchorTableFormat3 table', () => {
+            const data =' 0003 00BD 012D 0000 0000';
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseAnchorPoint(), {
+                format: 3,
+                xCoordinate: 189,
+                yCoordinate: 301,
+                xDevice: 0,
+                yDevice: 0
+            });
+        });
+    });
+
     describe('parseCoverage', function() {
         it('should parse a CoverageFormat1 table', function() {
             // https://www.microsoft.com/typography/OTSPEC/chapter2.htm Example 5

--- a/test/tables/gpos.js
+++ b/test/tables/gpos.js
@@ -138,4 +138,253 @@ describe('tables/gpos.js', function() {
             ]
         });
     });
+
+    //// Lookup type 4 ////////////////////////////////////////////////////////
+    it('can parse lookup4 MarkBasePosFormat1', () => {
+
+        const data = 
+            ` 0001` + // MarkMarkPosFormat1
+            ` 000C` + // markCoverageOffset
+            ` 0016` + // baseCoverageOffset
+            ` 0002` + // markClassCount
+            ` 001C` + // markArrayOffset
+            ` 0038` + // baseArrayOffset
+            ` 0002 0001 0045 0046 0000` + 
+            ` 0001 0001 0047` +
+            ` 0002  0000  000A   0001  0016  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1` + 
+            ` 0001    0006 000C  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1` + 
+            ``;
+
+        const expectedResult = {
+            posFormat: 1,
+            markCoverage: {
+                format: 2,
+                ranges: [
+                    { start: 0x45, end: 0x46, index: 0 }
+                ]
+            },
+            baseCoverage: {
+                glyphs: [71],
+                format: 1
+            },
+            markArray: [{
+                class: 0,
+                attachmentPoint: {
+                    format: 1,
+                    xCoordinate: 189,
+                    yCoordinate: 301
+                }
+            }, {
+                class: 1,
+                attachmentPoint: {
+                    format: 1,
+                    xCoordinate: 223,
+                    yCoordinate: -303
+                }
+            }],
+            baseArray: [
+                [{
+                    format: 1,
+                    xCoordinate: 189,
+                    yCoordinate: 301
+                }, 
+                {
+                    format: 1,
+                    xCoordinate: 221,
+                    yCoordinate: 302
+                }]
+            ]
+        };
+
+        assert.deepEqual(parseLookup(4, data), expectedResult);
+    });
+
+    //// Lookup type 9 ////////////////////////////////////////////////////////
+    describe('lookup9 ExtensionPosFormat1', () => {
+
+        it('should return an error message for unsupported lookup type: 3', () => {
+            const UnsupportedLookupType = '0003';
+            const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
+            assert.deepEqual(parseLookup(9, data), { 
+                posFormat: 1,
+                extensionLookupType: 3,
+                extension: { error: 'GPOS Lookup 3 not supported' }
+            });
+        });
+
+        it('should return an error message for unsupported lookup type: 5', () => {
+            const UnsupportedLookupType = '0005';
+            const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
+            assert.deepEqual(parseLookup(9, data), { 
+                posFormat: 1,
+                extensionLookupType: 5,
+                extension: { error: 'GPOS Lookup 5 not supported' }
+            });
+        });
+
+        it('should return an error message for unsupported lookup type: 6', () => {
+            const UnsupportedLookupType = '0006';
+            const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
+            assert.deepEqual(parseLookup(9, data), { 
+                posFormat: 1,
+                extensionLookupType: 6,
+                extension: { error: 'GPOS Lookup 6 not supported' }
+            });
+        });
+
+        it('should return an error message for unsupported lookup type: 7', () => {
+            const UnsupportedLookupType = '0007';
+            const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
+            assert.deepEqual(parseLookup(9, data), { 
+                posFormat: 1,
+                extensionLookupType: 7,
+                extension: { error: 'GPOS Lookup 7 not supported' }
+            });
+        });
+
+        it('should return an error message for unsupported lookup type: 8', () => {
+            const UnsupportedLookupType = '0008';
+            const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
+            assert.deepEqual(parseLookup(9, data), { 
+                posFormat: 1,
+                extensionLookupType: 8,
+                extension: { error: 'GPOS Lookup 8 not supported' }
+            });
+        });
+
+        it('can parse lookup1 extension table', () => {
+
+            const SinglePosFormat1data = '0001 0008 0002   FFB0 0002 0001   01B3 01BC 0000';
+            const data = 
+                ` 0001` +
+                ` 0001` + // extensionLookupType
+                ` 00000008` + // extensionLookupTableOffset
+                ` ${SinglePosFormat1data}` +
+                ``;
+
+            const expectedResult = {
+                posFormat: 1,
+                extensionLookupType: 1,
+                extension: {
+                    posFormat: 1,
+                    coverage: {
+                        format: 2,
+                        ranges: [{ start: 0x1b3, end: 0x1bc, index: 0 }]
+                    },
+                    value: { yPlacement: -80 }
+                }
+            };
+
+            assert.deepEqual(parseLookup(9, data), expectedResult);
+        }); 
+        
+        it('can parse lookup2 extension table', () => {
+
+            const lookup2Data = '0002 0018 0004 0000 0022 0032 0002 0002 0000 0000 0000 FFCE   0001 0003 0046 0047 0049   0002 0002 0046 0047 0001 0049 0049 0001   0002 0001 006A 006B 0001';
+            const data = 
+                ` 0001` +
+                ` 0002` + // extensionLookupType
+                ` 00000008` + // extensionLookupTableOffset
+                ` ${lookup2Data}` +
+                ``;
+
+            const expectedResult = {
+                posFormat: 1,
+                extensionLookupType: 2,
+                extension: {
+                    posFormat: 2,
+                    coverage: {
+                        format: 1,
+                        glyphs: [0x46, 0x47, 0x49]
+                    },
+                    valueFormat1: 4,
+                    valueFormat2: 0,
+                    classDef1: {
+                        format: 2,
+                        ranges: [
+                            { start: 0x46, end: 0x47, classId: 1 },
+                            { start: 0x49, end: 0x49, classId: 1 }
+                        ]
+                    },
+                    classDef2: {
+                        format: 2,
+                        ranges: [
+                            { start: 0x6a, end: 0x6b, classId: 1 }
+                        ]
+                    },
+                    class1Count: 2,
+                    class2Count: 2,
+                    classRecords: [
+                        [
+                            { value1: { xAdvance: 0 }, value2: undefined },
+                            { value1: { xAdvance: 0 }, value2: undefined }
+                        ],
+                        [
+                            { value1: { xAdvance: 0 }, value2: undefined },
+                            { value1: { xAdvance: -50 }, value2: undefined }
+                        ]
+                    ]
+                }
+            };
+
+            assert.deepEqual(parseLookup(9, data), expectedResult);
+        }); 
+
+        it('can parse lookup4 extension table', () => {
+
+            const MarkBasePosFormat1 = ' 0001 000C 0016 0002 001C 0038 0002 0001 0045 0046 0000 0001 0001 0047 0002  0000  000A   0001  0016  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1 0001    0006 000C  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1';
+            const data = 
+                ` 0001` +
+                ` 0004` + // extensionLookupType
+                ` 00000008` + // extensionLookupTableOffset
+                ` ${MarkBasePosFormat1}` +
+                ``;
+
+            const expectedResult = {
+                posFormat: 1,
+                extensionLookupType: 4,
+                extension: {
+                    posFormat: 1,
+                    markCoverage: {
+                        format: 2,
+                        ranges: [
+                            { start: 0x45, end: 0x46, index: 0 }
+                        ]
+                    },
+                    baseCoverage: {
+                        glyphs: [71],
+                        format: 1
+                    },
+                    markArray: [{
+                        class: 0,
+                        attachmentPoint: {
+                            format: 1,
+                            xCoordinate: 189,
+                            yCoordinate: 301
+                        }
+                    }, {
+                        class: 1,
+                        attachmentPoint: {
+                            format: 1,
+                            xCoordinate: 223,
+                            yCoordinate: -303
+                        }
+                    }],
+                    baseArray: [ 
+                        [{
+                            format: 1,
+                            xCoordinate: 189,
+                            yCoordinate: 301
+                        }, {
+                            format: 1,
+                            xCoordinate: 221,
+                            yCoordinate: 302
+                        }]
+                    ]
+                }
+            };
+
+            assert.deepEqual(parseLookup(9, data), expectedResult);
+        });
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

feat: additional GPOS lookups parsers support

- added GPOS LookupType 4 parser for MarkBasePosFormat1 support
- added GPOS LookupType 9 parser for Extension Positioning SubtableFormat1 support
- tests coverage for all supported and not supported lookups of GPOS

**TODO**: Add a support device offsets for anchor table format 3 (`src/parse.js:515`)
**TODO**: Add MarkToMark Attachment positioning (lookup type 6) functionality.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fonts like Mandarin or Thai to successfully render text with all glyphs (sometimes 3+) representing characters like `ปั` or `ริ่`
require lookup type 4 for mark to base attachment positioning to do it properly. 

[Extension subtables support is required](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning) to support the subtables that exceeds the 16-bit limits of the various other offsets in the GPOS table.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tests were added to `test/parser.js` including new binary data adapting:
- the [Lookup Type 4: Mark-to-Base Attachment Positioning Subtable specification](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-4-mark-to-base-attachment-positioning-subtable)
- the [LookupType 9: Extension Positioning](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning)

These lookups uses existing structures like coverage tables, and were tested agains different format of supported features. Extension positioning lookup was tested agains all supported and not supported subtable parsers.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
