### PR TITLE
feat: Support for Mark to Base Attachment Positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Features
 * Support for composite glyphs (accented letters).
 * Support for WOFF, OTF, TTF (both with TrueType `glyf` and PostScript `cff` outlines)
 * Support for kerning (Using GPOS or the kern table).
+* Support for Mark-to-Base Attachment Positioning.
 * Support for ligatures.
 * Support for TrueType font hinting.
 * Support arabic text rendering (See issue #364 & PR #359 #361)

--- a/src/features/positioning/index.js
+++ b/src/features/positioning/index.js
@@ -1,0 +1,2 @@
+export * from './kern';
+export * from './mark';

--- a/src/features/positioning/kern.js
+++ b/src/features/positioning/kern.js
@@ -7,9 +7,9 @@ function kern(lookupTable, glyphs) {
     for (let i = 0; i < glyphs.length; i += 1) {
         const glyph = glyphs[i];
         coords[i] = { xAdvance: 0, yAdvance: 0 };
-        if (i < glyphs.length - 1) {
+        if (i > 0) {
             coords[i] = {
-                xAdvance: this.position.getKerningValue([lookupTable], glyph.index, glyphs[i + 1].index),
+                xAdvance: this.position.getKerningValue([lookupTable], glyphs[i - 1].index, glyph.index),
                 yAdvance: 0
             };
         }

--- a/src/features/positioning/kern.js
+++ b/src/features/positioning/kern.js
@@ -8,9 +8,9 @@ function kern(lookupTable, glyphs) {
         const glyph = glyphs[i];
         coords[i] = { xAdvance: 0, yAdvance: 0 };
         if (i < glyphs.length - 1) {
-            coords[i] = { 
-                xAdvance: this.position.getKerningValue([lookupTable], glyph.index, glyphs[i + 1].index), 
-                yAdvance: 0 
+            coords[i] = {
+                xAdvance: this.position.getKerningValue([lookupTable], glyph.index, glyphs[i + 1].index),
+                yAdvance: 0
             };
         }
     }

--- a/src/features/positioning/kern.js
+++ b/src/features/positioning/kern.js
@@ -1,0 +1,20 @@
+/**
+ * Apply kerning positioning advance glyphs advance
+ */
+
+function kern(lookupTable, glyphs) {
+    const coords = [];
+    for (let i = 0; i < glyphs.length; i += 1) {
+        const glyph = glyphs[i];
+        coords[i] = { xAdvance: 0, yAdvance: 0 };
+        if (i < glyphs.length - 1) {
+            coords[i] = { 
+                xAdvance: this.position.getKerningValue([lookupTable], glyph.index, glyphs[i + 1].index), 
+                yAdvance: 0 
+            };
+        }
+    }
+    return coords;
+}
+
+export { kern };

--- a/src/features/positioning/mark.js
+++ b/src/features/positioning/mark.js
@@ -8,7 +8,7 @@ function mark(lookupTable, glyphs) {
         const glyph = glyphs[i];
         coords[i] = { xAdvance: 0, yAdvance: 0 };
         if (i > 0) {
-            const coordinatedPair = this.position.getMarkToBaseAttachment([lookupTable], glyph.index, glyphs[i - 1].index);
+            const coordinatedPair = this.position.getMarkToBaseAttachment([lookupTable], glyphs[i - 1].index, glyph.index);
             if (coordinatedPair) {
                 const { attachmentMarkPoint, baseMarkPoint } = coordinatedPair;
                 // Base mark's advanceWidth must be ignored to have a proper positiong for the attachment mark

--- a/src/features/positioning/mark.js
+++ b/src/features/positioning/mark.js
@@ -1,0 +1,25 @@
+/**
+ * Apply MarkToBase positioning advance glyphs advance
+ */
+
+function mark(lookupTable, glyphs) {
+    const coords = [];
+    for (let i = 0; i < glyphs.length; i += 1) {
+        const glyph = glyphs[i];
+        coords[i] = { xAdvance: 0, yAdvance: 0 };
+        if (i > 0) {
+            const coordinatedPair = this.position.getMarkToBaseAttachment([lookupTable], glyph.index, glyphs[i - 1].index);
+            if (coordinatedPair) { 
+                const { attachmentMarkPoint, baseMarkPoint } = coordinatedPair;
+                // Base mark's advanceWidth must be ignored to have a proper positiong for the attachment mark
+                coords[i] = { 
+                    xAdvance: baseMarkPoint.xCoordinate - attachmentMarkPoint.xCoordinate - glyphs[i - 1].advanceWidth,  
+                    yAdvance: baseMarkPoint.yCoordinate - attachmentMarkPoint.yCoordinate 
+                };
+            }
+        }
+    }
+    return coords;
+}
+
+export { mark };

--- a/src/features/positioning/mark.js
+++ b/src/features/positioning/mark.js
@@ -9,12 +9,12 @@ function mark(lookupTable, glyphs) {
         coords[i] = { xAdvance: 0, yAdvance: 0 };
         if (i > 0) {
             const coordinatedPair = this.position.getMarkToBaseAttachment([lookupTable], glyph.index, glyphs[i - 1].index);
-            if (coordinatedPair) { 
+            if (coordinatedPair) {
                 const { attachmentMarkPoint, baseMarkPoint } = coordinatedPair;
                 // Base mark's advanceWidth must be ignored to have a proper positiong for the attachment mark
-                coords[i] = { 
-                    xAdvance: baseMarkPoint.xCoordinate - attachmentMarkPoint.xCoordinate - glyphs[i - 1].advanceWidth,  
-                    yAdvance: baseMarkPoint.yCoordinate - attachmentMarkPoint.yCoordinate 
+                coords[i] = {
+                    xAdvance: baseMarkPoint.xCoordinate - attachmentMarkPoint.xCoordinate - glyphs[i - 1].advanceWidth,
+                    yAdvance: baseMarkPoint.yCoordinate - attachmentMarkPoint.yCoordinate
                 };
             }
         }

--- a/src/font.js
+++ b/src/font.js
@@ -355,6 +355,7 @@ Font.prototype.getGlyphsPositions = function(glyphs, options) {
     let kernLookupTableProcessed = false;
     const featuresLookups = this.position.getPositionFeatures(features, script, options.language);
     featuresLookups.forEach(lookupTable => {
+        let kerningValue = 0;
         let pos = [];
         switch (lookupTable.feature) {
             case 'kern':
@@ -368,15 +369,22 @@ Font.prototype.getGlyphsPositions = function(glyphs, options) {
 
         // Reposition glyphs
         pos.forEach((glyphPosition, index) => {
-            glyphsPositions[index].xAdvance += glyphPosition.xAdvance;
-            glyphsPositions[index].yAdvance += glyphPosition.yAdvance;
+            if (lookupTable.feature === 'kern') { 
+                kerningValue += glyphPosition.xAdvance; // kerning apply to entire sequence
+                glyphsPositions[index].xAdvance += kerningValue;
+            } else {
+                glyphsPositions[index].xAdvance += glyphPosition.xAdvance;
+                glyphsPositions[index].yAdvance += glyphPosition.yAdvance;
+            }
         });
     });
 
     // Support for the 'kern' table glyph pairs
     if (options.kerning && kernLookupTableProcessed === false) {
+        let kerningValue = 0;
         for (let i = 1; i < glyphs.length; i += 1) {
-            glyphsPositions[i].xAdvance += this.getKerningValue(glyphs[i - 1], glyphs[i]);
+            kerningValue += this.getKerningValue(glyphs[i - 1], glyphs[i]); // kerning apply to entire sequence
+            glyphsPositions[i].xAdvance += kerningValue; 
         }
     }
     return glyphsPositions;

--- a/src/font.js
+++ b/src/font.js
@@ -160,7 +160,7 @@ Font.prototype.updateFeatures = function (options) {
         if (configureable.includes(feature.script)) {
             return {
                 script: feature.script,
-                tags: feature.tags.filter(tag => ! options || options[tag])
+                tags: feature.tags.filter(tag => !options || options[tag])
             };
         }
         return feature;
@@ -189,7 +189,7 @@ Font.prototype.stringToGlyphs = function(s, options) {
     // Create and register 'glyphIndex' state modifier
     const charToGlyphIndexMod = token => this.charToGlyphIndex(token.char);
     bidi.registerModifier('glyphIndex', null, charToGlyphIndexMod);
-    
+
     const features = this.getFeaturesConfig(options);
     bidi.applyFeatures(this, features);
 
@@ -309,7 +309,7 @@ Font.prototype.forEachGlyph = function(text, x, y, fontSize, options, callback) 
     for (let i = 0; i < glyphs.length; i += 1) {
         const glyph = glyphs[i];
         const { xAdvance, yAdvance } = glyphsPositions[i];
-       
+
         callback.call(this, glyph, x + (xAdvance * fontScale), y + (yAdvance * fontScale), fontSize, options);
 
         if (glyph.advanceWidth) {
@@ -327,12 +327,12 @@ Font.prototype.forEachGlyph = function(text, x, y, fontSize, options, callback) 
 
 /**
  * Returns array of glyphs' relative position advances for a given sequence.
- * 
+ *
  * Supported features:
  * - kern - kerning
  * - mark - mark to base attachments
- * 
- * @param {opentype.Glyph[]} glyphs 
+ *
+ * @param {opentype.Glyph[]} glyphs
  * @returns {Object[]} array of { xAdvance: number, yAdvance: number } for a glyph ordered by their index
  */
 Font.prototype.getGlyphsPositions = function(glyphs, options) {
@@ -345,18 +345,18 @@ Font.prototype.getGlyphsPositions = function(glyphs, options) {
         .reduce((tags, feature) => tags.concat(feature.tags), []);
 
     // Force a kern feature
-    if (options && options.kerning) features.push('kern'); 
+    if (options && options.kerning) features.push('kern');
 
     const glyphsPositions = [];
     for (let i = 0; i < glyphs.length; i += 1) {
-        glyphsPositions[i] = { xAdvance:0, yAdvance:0 };
+        glyphsPositions[i] = { xAdvance: 0, yAdvance: 0 };
     }
 
     let kernLookupTableProcessed = false;
     const featuresLookups = this.position.getPositionFeatures(features, script, options.language);
     featuresLookups.forEach(lookupTable => {
         let pos = [];
-        switch(lookupTable.feature) {
+        switch (lookupTable.feature) {
             case 'kern':
                 pos = kern.call(this, lookupTable, glyphs);
                 kernLookupTableProcessed = true;
@@ -376,7 +376,7 @@ Font.prototype.getGlyphsPositions = function(glyphs, options) {
     // Support for the 'kern' table glyph pairs
     if (options.kerning && kernLookupTableProcessed === false) {
         for (let i = 0; i < glyphs.length - 1; i += 1) {
-            glyphsPositions[i].xAdvance += this.getKerningValue(glyphs[i], glyphs[i+1]);
+            glyphsPositions[i].xAdvance += this.getKerningValue(glyphs[i], glyphs[i + 1]);
         }
     }
     return glyphsPositions;

--- a/src/font.js
+++ b/src/font.js
@@ -375,8 +375,8 @@ Font.prototype.getGlyphsPositions = function(glyphs, options) {
 
     // Support for the 'kern' table glyph pairs
     if (options.kerning && kernLookupTableProcessed === false) {
-        for (let i = 0; i < glyphs.length - 1; i += 1) {
-            glyphsPositions[i].xAdvance += this.getKerningValue(glyphs[i], glyphs[i + 1]);
+        for (let i = 1; i < glyphs.length; i += 1) {
+            glyphsPositions[i].xAdvance += this.getKerningValue(glyphs[i - 1], glyphs[i]);
         }
     }
     return glyphsPositions;

--- a/src/layout.js
+++ b/src/layout.js
@@ -200,17 +200,17 @@ Layout.prototype = {
      * This follows an ordered processing requirements (specs):
      * > During text processing, it processes the lookups referenced by that feature in their lookup list order.
      * > Note that an application may process lookups for multiple features simultaneously. In this case:
-     * > the list of lookups is the union of lookups referenced by all of those features, and these are all processed in their lookup list order. 
-     * 
+     * > the list of lookups is the union of lookups referenced by all of those features, and these are all processed in their lookup list order.
+     *
      * https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/chapter2#lookup-list-table
-     * 
-     * @param {string[]} requestedFeatures 
+     *
+     * @param {string[]} requestedFeatures
      * @param {string} [script='DFLT']
      * @param {string} [language='dlft']
      * @return {Object[]} an ordered lookup list of requested features
      */
     getFeaturesLookups: function(requestedFeatures, script, language) {
-        if (! this.font.tables[this.tableName] || ! requestedFeatures) {
+        if (!this.font.tables[this.tableName] || !requestedFeatures) {
             return [];
         }
 
@@ -218,7 +218,7 @@ Layout.prototype = {
         requestedFeatures = this.supportedFeatures.filter(f => requestedFeatures.includes(f.featureName));
 
         const lookupUnionList = {};
-        const allLookups = this.font.tables[this.tableName].lookups; 
+        const allLookups = this.font.tables[this.tableName].lookups;
         requestedFeatures.forEach(feature => {
             const { featureName, supportedLookups } = feature;
             let featureTable = this.getFeatureTable(script, language, featureName);
@@ -232,7 +232,7 @@ Layout.prototype = {
                     if (!lookupTable) continue;
                     let validLookupType = supportedLookups.indexOf(lookupTable.lookupType) !== -1;
                     // Extension lookup table support
-                    if (lookupTable.subtables.length === 1) { 
+                    if (lookupTable.subtables.length === 1) {
                         const { extensionLookupType, extension } = lookupTable.subtables[0];
                         if (extensionLookupType && extension && supportedLookups.indexOf(extensionLookupType) !== -1) {
                             lookupTable.lookupType = extensionLookupType;

--- a/src/layout.js
+++ b/src/layout.js
@@ -64,9 +64,10 @@ function searchRange(ranges, value) {
  * @exports opentype.Layout
  * @class
  */
-function Layout(font, tableName) {
+function Layout(font, tableName, supportedFeatures) {
     this.font = font;
     this.tableName = tableName;
+    this.supportedFeatures = supportedFeatures || [];
 }
 
 Layout.prototype = {
@@ -192,6 +193,61 @@ Layout.prototype = {
                 return langSysRecord.langSys;
             }
         }
+    },
+
+    /**
+     * Returns an ordered, union lookup tables for all requested features.
+     * This follows an ordered processing requirements (specs):
+     * > During text processing, it processes the lookups referenced by that feature in their lookup list order.
+     * > Note that an application may process lookups for multiple features simultaneously. In this case:
+     * > the list of lookups is the union of lookups referenced by all of those features, and these are all processed in their lookup list order. 
+     * 
+     * https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/chapter2#lookup-list-table
+     * 
+     * @param {string[]} requestedFeatures 
+     * @param {string} [script='DFLT']
+     * @param {string} [language='dlft']
+     * @return {Object[]} an ordered lookup list of requested features
+     */
+    getFeaturesLookups: function(requestedFeatures, script, language) {
+        if (! this.font.tables[this.tableName] || ! requestedFeatures) {
+            return [];
+        }
+
+        // Fitler out only supported by layout table features
+        requestedFeatures = this.supportedFeatures.filter(f => requestedFeatures.includes(f.featureName));
+
+        const lookupUnionList = {};
+        const allLookups = this.font.tables[this.tableName].lookups; 
+        requestedFeatures.forEach(feature => {
+            const { featureName, supportedLookups } = feature;
+            let featureTable = this.getFeatureTable(script, language, featureName);
+            if (featureTable && supportedLookups.length) {
+                let lookupTable;
+                const lookupListIndexes = featureTable.lookupListIndexes;
+                for (let i = 0; i < lookupListIndexes.length; i++) {
+                    const idx = `idx${lookupListIndexes[i]}`;
+                    if (lookupUnionList.hasOwnProperty(idx)) continue; // Skips a lookup table that is already on the processing list
+                    lookupTable = allLookups[lookupListIndexes[i]];
+                    if (!lookupTable) continue;
+                    let validLookupType = supportedLookups.indexOf(lookupTable.lookupType) !== -1;
+                    // Extension lookup table support
+                    if (lookupTable.subtables.length === 1) { 
+                        const { extensionLookupType, extension } = lookupTable.subtables[0];
+                        if (extensionLookupType && extension && supportedLookups.indexOf(extensionLookupType) !== -1) {
+                            lookupTable.lookupType = extensionLookupType;
+                            lookupTable.subtables = [extension];
+                            validLookupType = true;
+                        }
+                    }
+                    if (validLookupType) {
+                        lookupTable.feature = featureName;
+                        lookupUnionList[idx] = lookupTable;
+                    }
+                }
+            }
+        });
+        return Object.values(lookupUnionList);
     },
 
     /**

--- a/src/parse.js
+++ b/src/parse.js
@@ -480,14 +480,14 @@ Parser.prototype.parseCoverage = function() {
 /**
  * Parse a BaseArray Table in GPOS table
  * https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/gpos#lookup-type-4-mark-to-base-attachment-positioning-subtable
- * 
- * @param {Number} marksClassCount 
+ *
+ * @param {Number} marksClassCount
  * @returns {Array}
  */
 Parser.prototype.parseBaseArray = function(marksClassCount) {
     const count = this.parseUShort();
     return this.parseList(count, Parser.list(
-        marksClassCount, 
+        marksClassCount,
         Parser.pointer(Parser.anchor)
     ));
 };
@@ -495,7 +495,7 @@ Parser.prototype.parseBaseArray = function(marksClassCount) {
 /**
  * Parse a MarkArray Table in GPOS table
  * https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/gpos_delta#mark-array-table
- * 
+ *
  * @returns {Array}
  */
 Parser.prototype.parseMarkArray = function() {
@@ -509,13 +509,13 @@ Parser.prototype.parseMarkArray = function() {
 /**
  * Parse a an anchor definition Table in GPOS table
  * https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/gpos_delta#anchor-tables
- * 
+ *
  * @returns {Object} Anchor object representing format type
  */
 Parser.prototype.parseAnchorPoint = function() {
     const startOffset = this.offset + this.relativeOffset;
     const format = this.parseUShort();
-    switch(format) {
+    switch (format) {
         case 1:
             return {
                 format,
@@ -537,7 +537,7 @@ Parser.prototype.parseAnchorPoint = function() {
                 format,
                 xCoordinate: this.parseShort(),
                 yCoordinate: this.parseShort(),
-                xDevice: 0x00, 
+                xDevice: 0x00,
                 yDevice: 0x00,
             };
     }

--- a/src/parse.js
+++ b/src/parse.js
@@ -477,6 +477,74 @@ Parser.prototype.parseCoverage = function() {
     throw new Error('0x' + startOffset.toString(16) + ': Coverage format must be 1 or 2.');
 };
 
+/**
+ * Parse a BaseArray Table in GPOS table
+ * https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/gpos#lookup-type-4-mark-to-base-attachment-positioning-subtable
+ * 
+ * @param {Number} marksClassCount 
+ * @returns {Array}
+ */
+Parser.prototype.parseBaseArray = function(marksClassCount) {
+    const count = this.parseUShort();
+    return this.parseList(count, Parser.list(
+        marksClassCount, 
+        Parser.pointer(Parser.anchor)
+    ));
+};
+
+/**
+ * Parse a MarkArray Table in GPOS table
+ * https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/gpos_delta#mark-array-table
+ * 
+ * @returns {Array}
+ */
+Parser.prototype.parseMarkArray = function() {
+    const count = this.parseUShort();
+    return this.parseRecordList(count, {
+        class: Parser.uShort,
+        attachmentPoint: Parser.pointer(Parser.anchor)
+    });
+};
+
+/**
+ * Parse a an anchor definition Table in GPOS table
+ * https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/gpos_delta#anchor-tables
+ * 
+ * @returns {Object} Anchor object representing format type
+ */
+Parser.prototype.parseAnchorPoint = function() {
+    const startOffset = this.offset + this.relativeOffset;
+    const format = this.parseUShort();
+    switch(format) {
+        case 1:
+            return {
+                format,
+                xCoordinate: this.parseShort(),
+                yCoordinate: this.parseShort()
+            };
+        case 2:
+            return {
+                format,
+                xCoordinate: this.parseShort(),
+                yCoordinate: this.parseShort(),
+                anchorPoint: this.parseUShort()
+            };
+
+        // TODO: Add a support Device offsets
+        // https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/gpos_delta#anchor-table-format-3-design-units-plus-device-or-variationindex-tables
+        case 3:
+            return {
+                format,
+                xCoordinate: this.parseShort(),
+                yCoordinate: this.parseShort(),
+                xDevice: 0x00, 
+                yDevice: 0x00,
+            };
+    }
+
+    throw new Error('0x' + startOffset.toString(16) + ': Anchor format must be 1, 2 or 3.');
+};
+
 // Parse a Class Definition Table in a GSUB, GPOS or GDEF table.
 // https://www.microsoft.com/typography/OTSPEC/chapter2.htm
 Parser.prototype.parseClassDef = function() {
@@ -548,6 +616,7 @@ Parser.uLong = Parser.offset32 = Parser.prototype.parseULong;
 Parser.uLongList = Parser.prototype.parseULongList;
 Parser.struct = Parser.prototype.parseStruct;
 Parser.coverage = Parser.prototype.parseCoverage;
+Parser.anchor = Parser.prototype.parseAnchorPoint;
 Parser.classDef = Parser.prototype.parseClassDef;
 
 ///// Script, Feature, Lookup lists ///////////////////////////////////////////////

--- a/src/position.js
+++ b/src/position.js
@@ -66,12 +66,11 @@ Position.prototype.getKerningValue = function(kerningLookups, leftIndex, rightIn
 
 /**
  * Find a mark to base attachment pair
- *
- * @param {integer} markGlyphIndex - attached mark glyph index
  * @param {integer} baseGlyphIndex - base glyph index
+ * @param {integer} markGlyphIndex - attached mark glyph index
  * @returns {Object[]}
  */
-Position.prototype.getMarkToBaseAttachment = function(lookupTables, markGlyphIndex, baseGlyphIndex) {
+Position.prototype.getMarkToBaseAttachment = function(lookupTables, baseGlyphIndex, markGlyphIndex) {
     for (let i = 0; i < lookupTables.length; i++) {
         const subtables = lookupTables[i].subtables;
         for (let j = 0; j < subtables.length; j++) {

--- a/src/position.js
+++ b/src/position.js
@@ -65,7 +65,7 @@ Position.prototype.getKerningValue = function(kerningLookups, leftIndex, rightIn
 };
 
 /**
- * Find a mark to base attachment pair 
+ * Find a mark to base attachment pair
  *
  * @param {integer} markGlyphIndex - attached mark glyph index
  * @param {integer} baseGlyphIndex - base glyph index
@@ -105,18 +105,18 @@ Position.prototype.getKerningTables = function(script, language) {
 };
 
 /**
- * Assembling features into ordered lookup list 
+ * Assembling features into ordered lookup list
  * Assemble all features (including any required feature) for the glyph run’s language system.
- * Assemble all lookups in these features, in LookupList order, removing any duplicates. 
- * 
+ * Assemble all lookups in these features, in LookupList order, removing any duplicates.
+ *
  * https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/chapter2#lookup-table
- * 
- * @param {string[]} list of requested features  
- * @param {string} script 
- * @param {string} language 
- * @return {Object[]} ordered lookup processing list 
+ *
+ * @param {string[]} list of requested features
+ * @param {string} script
+ * @param {string} language
+ * @return {Object[]} ordered lookup processing list
  */
-Position.prototype.getPositionFeatures = function(features, script, language) {  
+Position.prototype.getPositionFeatures = function(features, script, language) {
     return this.getFeaturesLookups(features, script, language);
 };
 

--- a/src/substitution.js
+++ b/src/substitution.js
@@ -12,7 +12,10 @@ import Layout from './layout';
  * @constructor
  */
 function Substitution(font) {
-    Layout.call(this, font, 'gsub');
+    Layout.call(this, font, 'gsub', [
+        { featureName: 'rlig',  supportedLookups: [4] }
+        // TODO: Define all supported features to use layout.getFeaturesLookups for a sequence ordered feature lookups
+    ]); 
 }
 
 // Check if 2 arrays of primitives are equal.

--- a/src/substitution.js
+++ b/src/substitution.js
@@ -15,7 +15,7 @@ function Substitution(font) {
     Layout.call(this, font, 'gsub', [
         { featureName: 'rlig',  supportedLookups: [4] }
         // TODO: Define all supported features to use layout.getFeaturesLookups for a sequence ordered feature lookups
-    ]); 
+    ]);
 }
 
 // Check if 2 arrays of primitives are equal.

--- a/src/tables/gpos.js
+++ b/src/tables/gpos.js
@@ -77,12 +77,47 @@ subtableParsers[2] = function parseLookup2() {
 };
 
 subtableParsers[3] = function parseLookup3() { return { error: 'GPOS Lookup 3 not supported' }; };
-subtableParsers[4] = function parseLookup4() { return { error: 'GPOS Lookup 4 not supported' }; };
+
+// https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-4-mark-to-base-attachment-positioning-subtable
+subtableParsers[4] = function parseLookup4() {
+    const start = this.offset + this.relativeOffset;
+    const posFormat = this.parseUShort();
+    check.assert(posFormat === 1, '0x' + start.toString(16) + ': GPOS lookup type 4 format must be 1.');
+    const markCoverage = this.parsePointer(Parser.coverage);
+    const baseCoverage = this.parsePointer(Parser.coverage);
+    const markClassCount = this.parseUShort();
+    const markArray = this.parsePointer(function() {
+        return this.parseMarkArray();
+    });
+    const baseArray = this.parsePointer(function() {
+        return this.parseBaseArray(markClassCount);
+    });
+    return {
+        posFormat,
+        markCoverage,
+        baseCoverage,
+        markArray,
+        baseArray
+    };
+};
+
 subtableParsers[5] = function parseLookup5() { return { error: 'GPOS Lookup 5 not supported' }; };
 subtableParsers[6] = function parseLookup6() { return { error: 'GPOS Lookup 6 not supported' }; };
 subtableParsers[7] = function parseLookup7() { return { error: 'GPOS Lookup 7 not supported' }; };
 subtableParsers[8] = function parseLookup8() { return { error: 'GPOS Lookup 8 not supported' }; };
-subtableParsers[9] = function parseLookup9() { return { error: 'GPOS Lookup 9 not supported' }; };
+
+// https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning
+subtableParsers[9] = function parseLookup9() {
+    const start = this.offset + this.relativeOffset;
+    const posFormat = this.parseUShort();
+    check.assert(posFormat === 1, '0x' + start.toString(16) + ': GPOS lookup type 9 format must be 1.');
+    const extensionLookupType = this.parseUShort();
+    return {
+        posFormat,
+        extensionLookupType,
+        extension: this.parsePointer32(subtableParsers[extensionLookupType])
+    };
+};
 
 // https://docs.microsoft.com/en-us/typography/opentype/spec/gpos
 function parseGposTable(data, start) {

--- a/test/font.js
+++ b/test/font.js
@@ -164,10 +164,10 @@ describe('font.js', function() {
 
             it('supports a kern table if no kern lookup tables set', () => {
                 const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
-                assert.deepStrictEqual(result, [{ xAdvance: 18, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 }]);
+                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 18, yAdvance: 0 }]);
 
                 const result2 = font.getGlyphsPositions([ffGlyph, fGlyph], { kerning: true });
-                assert.deepStrictEqual(result2, [{ xAdvance: -9, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 }]);
+                assert.deepStrictEqual(result2, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: -9, yAdvance: 0 }]);
             });
 
             it('supports a kern lookup tables', () => {
@@ -208,7 +208,7 @@ describe('font.js', function() {
                 };
 
                 const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
-                assert.deepStrictEqual(result, [{ xAdvance: -91, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 }]);
+                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: -91, yAdvance: 0 }]);
             });
 
             it('can be disabled with options.kerning flag', () => {
@@ -294,7 +294,7 @@ describe('font.js', function() {
                 };
 
                 const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
-                assert.deepStrictEqual(result, [{ xAdvance: 32, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 }]);
+                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 676, yAdvance: -721 }]);
             });
 
             it('is enabled by default', () => {

--- a/test/font.js
+++ b/test/font.js
@@ -142,6 +142,9 @@ describe('font.js', function() {
 
     describe('Positioning features support', () => {
         describe('KERN - Kerning', () => {
+
+            const fGlyph = new Glyph({name: 'f', unicode: 102, path: new Path(), advanceWidth: 1, index: 1 });
+
             beforeEach(() => {
                 font.tables.gpos = {
                     version: 1,
@@ -158,16 +161,18 @@ describe('font.js', function() {
 
                 font.kerningPairs = {
                     [`${ffGlyph.index},${ffiGlyph.index}`]: 18,
-                    [`${ffGlyph.index},${fGlyph.index}`]: -9
+                    [`${ffGlyph.index},${fGlyph.index}`]: -9,
+                    [`${fGlyph.index},${ffGlyph.index}`]: 20,
+                    [`${ffiGlyph.index},${fGlyph.index}`]: -30
                 };
             });
 
             it('supports a kern table if no kern lookup tables set', () => {
-                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
-                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 18, yAdvance: 0 }]);
+                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph, fGlyph, ffGlyph], { kerning: true });
+                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 18, yAdvance: 0 }, { xAdvance: 18 - 30, yAdvance: 0 }, { xAdvance: 18 - 30 + 20, yAdvance: 0 }]);
 
-                const result2 = font.getGlyphsPositions([ffGlyph, fGlyph], { kerning: true });
-                assert.deepStrictEqual(result2, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: -9, yAdvance: 0 }]);
+                const result2 = font.getGlyphsPositions([ffGlyph, fGlyph, fGlyph, ffGlyph], { kerning: true });
+                assert.deepStrictEqual(result2, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: -9 + 0, yAdvance: 0 }, { xAdvance: -9 + 0, yAdvance: 0 }, { xAdvance: -9 + 20, yAdvance: 0 }]);
             });
 
             it('supports a kern lookup tables', () => {
@@ -192,13 +197,19 @@ describe('font.js', function() {
                                 posFormat: 1,
                                 coverage: {
                                     format: 1,
-                                    glyphs: [3]
+                                    glyphs: [3, 5]
                                 },
                                 pairSets: [
                                     [{
                                         secondGlyph: 5,
                                         value1: {
                                             xAdvance: -91
+                                        }
+                                    }],
+                                    [{
+                                        secondGlyph: 1,
+                                        value1: {
+                                            xAdvance: -11
                                         }
                                     }]
                                 ]
@@ -207,13 +218,13 @@ describe('font.js', function() {
                     ]
                 };
 
-                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
-                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: -91, yAdvance: 0 }]);
+                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph, fGlyph, fGlyph], { kerning: true });
+                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: -91, yAdvance: 0 }, { xAdvance: -91 - 11, yAdvance: 0 }, { xAdvance: -91 - 11, yAdvance: 0 }]);
             });
 
             it('can be disabled with options.kerning flag', () => {
-                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: false });
-                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 }]);
+                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph, fGlyph], { kerning: false });
+                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 }]);
             });
         });
 
@@ -289,12 +300,12 @@ describe('font.js', function() {
 
             it('supports a mark feature with kern feature', () => {
                 font.kerningPairs = {
-                    [`${ffGlyph.index},${ffiGlyph.index}`]: 32,
+                    [`${ffGlyph.index},${ffiGlyph.index}`]: -15,
                     [`${ffGlyph.index},${fGlyph.index}`]: -9
                 };
 
-                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
-                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 676, yAdvance: -721 }]);
+                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph, fGlyph, fiGlyph], { kerning: true });
+                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 644 - 15, yAdvance: -721 }, { xAdvance: -15, yAdvance: 0 }, { xAdvance: -15, yAdvance: 0 }]);
             });
 
             it('is enabled by default', () => {

--- a/test/font.js
+++ b/test/font.js
@@ -4,11 +4,11 @@ import { Font, Glyph, Path, loadSync } from '../src/opentype';
 describe('font.js', function() {
     let font;
 
-    const fGlyph = new Glyph({name: 'f', unicode: 102, path: new Path(), advanceWidth: 1});
-    const iGlyph = new Glyph({name: 'i', unicode: 105, path: new Path(), advanceWidth: 1});
-    const ffGlyph = new Glyph({name: 'f_f', unicode: 0xfb01, path: new Path(), advanceWidth: 1});
-    const fiGlyph = new Glyph({name: 'f_i', unicode: 0xfb02, path: new Path(), advanceWidth: 1});
-    const ffiGlyph = new Glyph({name: 'f_f_i', unicode: 0xfb03, path: new Path(), advanceWidth: 1});
+    const fGlyph = new Glyph({name: 'f', unicode: 102, path: new Path(), advanceWidth: 1, index: 1 });
+    const iGlyph = new Glyph({name: 'i', unicode: 105, path: new Path(), advanceWidth: 1, index: 2 });
+    const ffGlyph = new Glyph({name: 'f_f', unicode: 0xfb01, path: new Path(), advanceWidth: 1, index: 3 });
+    const fiGlyph = new Glyph({name: 'f_i', unicode: 0xfb02, path: new Path(), advanceWidth: 1, index: 4 });
+    const ffiGlyph = new Glyph({name: 'f_f_i', unicode: 0xfb03, path: new Path(), advanceWidth: 1, index: 5 });
 
     const glyphs = [
         new Glyph({name: '.notdef', unicode: 0, path: new Path(), advanceWidth: 1}),
@@ -26,6 +26,8 @@ describe('font.js', function() {
             tables: {os2: {achVendID: 'TEST'}},
             glyphs: glyphs
         });
+
+        font.kerningPairs = {};
     });
 
     describe('Font constructor', function() {
@@ -72,6 +74,241 @@ describe('font.js', function() {
             assert.equal(glyphs.length, 1);
             assert.equal(glyphs[0].name, 'er');
         });
+    });
 
+    describe('getFeaturesConfig', () => {
+        it('returns default rendering config if options are ommited', () => {
+            const configResult = font.getFeaturesConfig();
+            assert.deepStrictEqual(configResult, [
+                { script: 'arab', tags: ['init', 'medi', 'fina', 'rlig'] },
+                { script: 'latn', tags: ['liga', 'rlig'] },
+                { script: 'DFLT', tags: ['mark'] },
+            ]);
+        });
+
+        it('returns default rendering config if features attribute is ommited', () => {
+            const configResult = font.getFeaturesConfig({
+                // features: {} // ommited
+            });
+            assert.deepStrictEqual(configResult, [
+                { script: 'arab', tags: ['init', 'medi', 'fina', 'rlig'] },
+                { script: 'latn', tags: ['liga', 'rlig'] },
+                { script: 'DFLT', tags: ['mark'] },
+            ]);
+        });
+
+        it('allows to update features for supported scripts (DFLT, latn)', () => {
+            const configResult = font.getFeaturesConfig({
+                features: {}
+            });
+
+            assert.deepStrictEqual(configResult, [
+                { script: 'arab', tags: ['init', 'medi', 'fina', 'rlig'] },
+                { script: 'latn', tags: [] },
+                { script: 'DFLT', tags: [] },
+            ]);
+
+            const configResult2 = font.getFeaturesConfig({
+                features: { liga: true, mark: true }
+            });
+
+            assert.deepStrictEqual(configResult2, [
+                { script: 'arab', tags: ['init', 'medi', 'fina', 'rlig'] },
+                { script: 'latn', tags: ['liga'] },
+                { script: 'DFLT', tags: ['mark'] },
+            ]);
+
+            const configResult3 = font.getFeaturesConfig({
+                features: { liga: true, rlig: true, mark: true }
+            });
+
+            assert.deepStrictEqual(configResult3, [
+                { script: 'arab', tags: ['init', 'medi', 'fina', 'rlig'] },
+                { script: 'latn', tags: ['liga', 'rlig'] },
+                { script: 'DFLT', tags: ['mark'] },
+            ]);
+
+            const configResult4 = font.getFeaturesConfig({
+                features: { liga: false, rlig: true, mark: false }
+            });
+
+            assert.deepStrictEqual(configResult4, [
+                { script: 'arab', tags: ['init', 'medi', 'fina', 'rlig'] },
+                { script: 'latn', tags: ['rlig'] },
+                { script: 'DFLT', tags: [] },
+            ]);
+        });
+    });
+
+    describe('Positioning features support', () => {
+        describe('KERN - Kerning', () => {
+            beforeEach(() => {
+                font.tables.gpos = {
+                    version: 1,
+                    scripts: [{
+                        tag: 'DFLT',
+                        script: {
+                            defaultLangSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [] },
+                            langSysRecords: []
+                        }
+                    }],
+                    features: [],
+                    lookups: []
+                };
+                
+                font.kerningPairs = {
+                    [`${ffGlyph.index},${ffiGlyph.index}`]: 18,
+                    [`${ffGlyph.index},${fGlyph.index}`]: -9
+                };
+            });
+
+            it('supports a kern table if no kern lookup tables set', () => {
+                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
+                assert.deepStrictEqual(result, [ { xAdvance: 18, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 } ]);
+
+                const result2 = font.getGlyphsPositions([ffGlyph, fGlyph], { kerning: true });
+                assert.deepStrictEqual(result2, [ { xAdvance: -9, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 } ]);
+            });
+
+            it('supports a kern lookup tables', () => {
+                font.tables.gpos = {
+                    version: 1,
+                    scripts: [{
+                        tag: 'DFLT',
+                        script: {
+                            defaultLangSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [0] },
+                            langSysRecords: []
+                        }
+                    }],
+                    features: [{
+                        tag: 'kern',
+                        feature: { featureParams: 0, lookupListIndexes: [0]}
+                    }],
+                    lookups: [
+                        {
+                            'lookupType': 2,
+                            'lookupFlag': 0,
+                            'subtables': [{
+                                'posFormat': 1,
+                                'coverage': {
+                                    'format': 1,
+                                    'glyphs': [3]
+                                },
+                                'pairSets': [
+                                    [{
+                                        'secondGlyph': 5,
+                                        'value1': {
+                                            'xAdvance': -91
+                                        }
+                                    }]
+                                ]
+                            }]
+                        }
+                    ]
+                };
+                
+                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
+                assert.deepStrictEqual(result, [ { xAdvance: -91, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 } ]);
+            });
+
+            it('can be disabled with options.kerning flag', () => {
+                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: false });
+                assert.deepStrictEqual(result, [ { xAdvance: 0, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 } ]);
+            });
+        });
+        
+        describe('MARK - MarkToBase Attachment', () => {
+            beforeEach(() => {
+                font.tables.gpos = {
+                    version: 1,
+                    scripts: [{
+                        tag: 'DFLT',
+                        script: {
+                            defaultLangSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [0] },
+                            langSysRecords: []
+                        }
+                    }, {
+                        tag: 'arab',
+                        script: {
+                            defaultLangSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [0] },
+                            langSysRecords: []
+                        }
+                    }],
+                    features: [{
+                        tag: 'mark',
+                        feature: { featureParams: 0, lookupListIndexes: [0]}
+                    }],
+                    lookups: [{
+                        'lookupType': 4,
+                        'lookupFlag': 0,
+                        'subtables': [{
+                            'posFormat': 1,
+                            'markCoverage': {
+                                'format': 1,
+                                'glyphs': [5]
+                            },
+                            'baseCoverage': {
+                                'format': 2,
+                                'ranges': [{
+                                    'start': 2,
+                                    'end': 4,
+                                    'index': 0
+                                }]
+                            },
+                            'markArray': [{
+                                'class': 0,
+                                'attachmentPoint': {
+                                    'format': 1,
+                                    'xCoordinate': -134,
+                                    'yCoordinate': 812
+                                }
+                            }],
+                            'baseArray': [
+                                [{
+                                    'format': 1,
+                                    'xCoordinate': -133,
+                                    'yCoordinate': -500
+                                }],
+                                [{
+                                    'format': 1,
+                                    'xCoordinate': 511,
+                                    'yCoordinate': 91
+                                }]
+                            ]
+                        }]
+                    }]
+                };
+
+                font.kerningPairs = {};
+            });
+
+            it('supports a mark lookup table', () => {
+                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
+                assert.deepStrictEqual(result, [ { xAdvance: 0, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 } ]);
+            });
+
+            it('supports a mark feature with kern feature', () => {
+                font.kerningPairs = {
+                    [`${ffGlyph.index},${ffiGlyph.index}`]: 32,
+                    [`${ffGlyph.index},${fGlyph.index}`]: -9
+                };
+
+                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
+                assert.deepStrictEqual(result, [ { xAdvance: 32, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 } ]);
+            });
+
+            it('is enabled by default', () => {
+                const resultDFLT = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: false });
+                assert.deepStrictEqual(resultDFLT, [ { xAdvance: 0, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 } ]);
+
+                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: false, script: 'arab' });
+                assert.deepStrictEqual(result, [ { xAdvance: 0, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 } ]);
+            });
+
+            it('can be disabled with options.features.mark flag', () => {
+                const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { features: { mark: false } });
+                assert.deepStrictEqual(result, [ { xAdvance: 0, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 } ]);
+            });
+        });
     });
 });

--- a/test/font.js
+++ b/test/font.js
@@ -155,7 +155,7 @@ describe('font.js', function() {
                     features: [],
                     lookups: []
                 };
-                
+
                 font.kerningPairs = {
                     [`${ffGlyph.index},${ffiGlyph.index}`]: 18,
                     [`${ffGlyph.index},${fGlyph.index}`]: -9
@@ -164,10 +164,10 @@ describe('font.js', function() {
 
             it('supports a kern table if no kern lookup tables set', () => {
                 const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
-                assert.deepStrictEqual(result, [ { xAdvance: 18, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 } ]);
+                assert.deepStrictEqual(result, [{ xAdvance: 18, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 }]);
 
                 const result2 = font.getGlyphsPositions([ffGlyph, fGlyph], { kerning: true });
-                assert.deepStrictEqual(result2, [ { xAdvance: -9, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 } ]);
+                assert.deepStrictEqual(result2, [{ xAdvance: -9, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 }]);
             });
 
             it('supports a kern lookup tables', () => {
@@ -186,19 +186,19 @@ describe('font.js', function() {
                     }],
                     lookups: [
                         {
-                            'lookupType': 2,
-                            'lookupFlag': 0,
-                            'subtables': [{
-                                'posFormat': 1,
-                                'coverage': {
-                                    'format': 1,
-                                    'glyphs': [3]
+                            lookupType: 2,
+                            lookupFlag: 0,
+                            subtables: [{
+                                posFormat: 1,
+                                coverage: {
+                                    format: 1,
+                                    glyphs: [3]
                                 },
-                                'pairSets': [
+                                pairSets: [
                                     [{
-                                        'secondGlyph': 5,
-                                        'value1': {
-                                            'xAdvance': -91
+                                        secondGlyph: 5,
+                                        value1: {
+                                            xAdvance: -91
                                         }
                                     }]
                                 ]
@@ -206,17 +206,17 @@ describe('font.js', function() {
                         }
                     ]
                 };
-                
+
                 const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
-                assert.deepStrictEqual(result, [ { xAdvance: -91, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 } ]);
+                assert.deepStrictEqual(result, [{ xAdvance: -91, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 }]);
             });
 
             it('can be disabled with options.kerning flag', () => {
                 const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: false });
-                assert.deepStrictEqual(result, [ { xAdvance: 0, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 } ]);
+                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 }]);
             });
         });
-        
+
         describe('MARK - MarkToBase Attachment', () => {
             beforeEach(() => {
                 font.tables.gpos = {
@@ -239,40 +239,40 @@ describe('font.js', function() {
                         feature: { featureParams: 0, lookupListIndexes: [0]}
                     }],
                     lookups: [{
-                        'lookupType': 4,
-                        'lookupFlag': 0,
-                        'subtables': [{
-                            'posFormat': 1,
-                            'markCoverage': {
-                                'format': 1,
-                                'glyphs': [5]
+                        lookupType: 4,
+                        lookupFlag: 0,
+                        subtables: [{
+                            posFormat: 1,
+                            markCoverage: {
+                                format: 1,
+                                glyphs: [5]
                             },
-                            'baseCoverage': {
-                                'format': 2,
-                                'ranges': [{
-                                    'start': 2,
-                                    'end': 4,
-                                    'index': 0
+                            baseCoverage: {
+                                format: 2,
+                                ranges: [{
+                                    start: 2,
+                                    end: 4,
+                                    index: 0
                                 }]
                             },
-                            'markArray': [{
-                                'class': 0,
-                                'attachmentPoint': {
-                                    'format': 1,
-                                    'xCoordinate': -134,
-                                    'yCoordinate': 812
+                            markArray: [{
+                                class: 0,
+                                attachmentPoint: {
+                                    format: 1,
+                                    xCoordinate: -134,
+                                    yCoordinate: 812
                                 }
                             }],
-                            'baseArray': [
+                            baseArray: [
                                 [{
-                                    'format': 1,
-                                    'xCoordinate': -133,
-                                    'yCoordinate': -500
+                                    format: 1,
+                                    xCoordinate: -133,
+                                    yCoordinate: -500
                                 }],
                                 [{
-                                    'format': 1,
-                                    'xCoordinate': 511,
-                                    'yCoordinate': 91
+                                    format: 1,
+                                    xCoordinate: 511,
+                                    yCoordinate: 91
                                 }]
                             ]
                         }]
@@ -284,7 +284,7 @@ describe('font.js', function() {
 
             it('supports a mark lookup table', () => {
                 const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
-                assert.deepStrictEqual(result, [ { xAdvance: 0, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 } ]);
+                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 }]);
             });
 
             it('supports a mark feature with kern feature', () => {
@@ -294,20 +294,20 @@ describe('font.js', function() {
                 };
 
                 const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: true });
-                assert.deepStrictEqual(result, [ { xAdvance: 32, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 } ]);
+                assert.deepStrictEqual(result, [{ xAdvance: 32, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 }]);
             });
 
             it('is enabled by default', () => {
                 const resultDFLT = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: false });
-                assert.deepStrictEqual(resultDFLT, [ { xAdvance: 0, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 } ]);
+                assert.deepStrictEqual(resultDFLT, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 }]);
 
                 const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { kerning: false, script: 'arab' });
-                assert.deepStrictEqual(result, [ { xAdvance: 0, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 } ]);
+                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 644, yAdvance: -721 }]);
             });
 
             it('can be disabled with options.features.mark flag', () => {
                 const result = font.getGlyphsPositions([ffGlyph, ffiGlyph], { features: { mark: false } });
-                assert.deepStrictEqual(result, [ { xAdvance: 0, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 } ]);
+                assert.deepStrictEqual(result, [{ xAdvance: 0, yAdvance: 0 }, { xAdvance: 0, yAdvance: 0 }]);
             });
         });
     });

--- a/test/layout.js
+++ b/test/layout.js
@@ -1,10 +1,12 @@
 import assert  from 'assert';
 import { Font, Path, Glyph } from '../src/opentype';
-import Layout  from '../src/layout';
+import Position from '../src/position';
+import Substitution from '../src/substitution';
 
 describe('layout.js', function() {
     let font;
     let layout;
+    let posLayout;
     const notdefGlyph = new Glyph({
         name: '.notdef',
         unicode: 0,
@@ -34,8 +36,11 @@ describe('layout.js', function() {
             descender: -200,
             glyphs: glyphs
         });
-        layout = new Layout(font, 'gsub');
+        layout = new Substitution(font);
         layout.createDefaultTable = function() { return defaultLayoutTable; };
+
+        posLayout = new Position(font);
+        posLayout.createDefaultTable = function() { return defaultLayoutTable; };
     });
 
     describe('getTable', function() {
@@ -152,5 +157,547 @@ describe('layout.js', function() {
             assert.equal(layout.getCoverageIndex(cov2, 55), -1);
             assert.equal(layout.getCoverageIndex(cov2, 70), -1);
         });
+    });
+
+    describe('getFeaturesLookups', () => {
+
+        beforeEach(() => {
+            font.tables.gpos = {
+                version: 1,
+                scripts: [{
+                    tag: 'DFLT',
+                    script: {
+                        defaultLangSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [0, 1] },
+                        langSysRecords: []
+                    }
+                }, {
+                    tag: 'latn',
+                    script: {
+                        defaultLangSys: { reserved: 0, reqFeatureIndex: 0xffff, featureIndexes: [0] },
+                        langSysRecords: []
+                    }
+                }],
+                features: [{
+                    tag: 'mark',
+                    feature: { featureParams: 0, lookupListIndexes: [1]}
+                }, {
+                    tag: 'kern',
+                    feature: { featureParams: 0, lookupListIndexes: [0]}
+                }],
+                lookups: [
+                    {
+                        lookupType: 2,
+                        lookupFlag: 0,
+                        subtables: [{
+                            posFormat: 1,
+                            coverage: {
+                                format: 1,
+                                glyphs: [3]
+                            },
+                            pairSets: [
+                                [{
+                                    secondGlyph: 5,
+                                    value1: { xAdvance: -91 }
+                                }]
+                            ]
+                        }]
+                    },
+                    {
+                    lookupType: 4,
+                    lookupFlag: 0,
+                    subtables: [{
+                        posFormat: 1,
+                        markCoverage: {
+                            format: 1,
+                            glyphs: [5]
+                        },
+                        baseCoverage: {
+                            format: 2,
+                            ranges: [{
+                                start: 2,
+                                end: 4,
+                                index: 0
+                            }]
+                        },
+                        markArray: [{
+                            class: 0,
+                            attachmentPoint: {
+                                format: 1,
+                                xCoordinate: -134,
+                                yCoordinate: 812
+                            }
+                        }],
+                        baseArray: [
+                            [{
+                                format: 1,
+                                xCoordinate: -133,
+                                yCoordinate: -500
+                            }],
+                            [{
+                                format: 1,
+                                xCoordinate: 511,
+                                yCoordinate: 91
+                            }]
+                        ]
+                    }]
+                }]
+            };
+        });
+
+        it('should return no lookups tables if layout table is empty', () => {
+            font.tables = [];
+            const result = posLayout.getFeaturesLookups(['mark']);
+            assert.deepStrictEqual(result, []);
+        });
+
+        it('should return no lookups tables if is data table is empty', () => {
+            font.tables.gpos.lookups = [];
+            const result = posLayout.getFeaturesLookups(['mark']);
+            assert.deepStrictEqual(result, []);
+        });
+
+        it('should return an ordered, union features lookup tables', () => {
+            const result = posLayout.getFeaturesLookups(['mark', 'kern', 'mkmk']);
+            assert.deepStrictEqual(result, [
+                {
+                    feature: 'kern',
+                    lookupType: 2,
+                    lookupFlag: 0,
+                    subtables: [{
+                        posFormat: 1,
+                        coverage: {
+                            format: 1,
+                            glyphs: [3]
+                        },
+                        pairSets: [
+                            [{
+                                secondGlyph: 5,
+                                value1: { xAdvance: -91 }
+                            }]
+                        ]
+                    }]
+                },
+                {
+                    feature: 'mark',
+                    lookupType: 4,
+                    lookupFlag: 0,
+                    subtables: [{
+                        posFormat: 1,
+                        markCoverage: {
+                            format: 1,
+                            glyphs: [5]
+                        },
+                        baseCoverage: {
+                            format: 2,
+                            ranges: [{
+                                start: 2,
+                                end: 4,
+                                index: 0
+                            }]
+                        },
+                        markArray: [{
+                            class: 0,
+                            attachmentPoint: {
+                                format: 1,
+                                xCoordinate: -134,
+                                yCoordinate: 812
+                            }
+                        }],
+                        baseArray: [
+                            [{
+                                format: 1,
+                                xCoordinate: -133,
+                                yCoordinate: -500
+                            }],
+                            [{
+                                format: 1,
+                                xCoordinate: 511,
+                                yCoordinate: 91
+                            }]
+                        ]
+                    }]
+                }]);
+        });
+
+        it('should return only supported features', () => {
+            posLayout.supportedFeatures = [{ featureName: 'kern',  supportedLookups: [2]  }];
+            const result = posLayout.getFeaturesLookups(['mark', 'kern', 'mkmk']);
+            assert.deepStrictEqual(result, [
+                {
+                    feature: 'kern',
+                    lookupType: 2,
+                    lookupFlag: 0,
+                    subtables: [{
+                        posFormat: 1,
+                        coverage: {
+                            format: 1,
+                            glyphs: [3]
+                        },
+                        pairSets: [
+                            [{
+                                secondGlyph: 5,
+                                value1: { xAdvance: -91 }
+                            }]
+                        ]
+                    }]
+                }]);
+        });
+
+        it('should not return supported features with not supported lookups', () => {
+            posLayout.supportedFeatures[0].supportedLookups = [8]; // This lookup 8 is not supported for the requested feature index
+            const result = posLayout.getFeaturesLookups(['mark', 'kern', 'mkmk']);
+            assert.deepStrictEqual(result, [
+                {
+                    feature: 'mark',
+                    lookupType: 4,
+                    lookupFlag: 0,
+                    subtables: [{
+                        posFormat: 1,
+                        markCoverage: {
+                            format: 1,
+                            glyphs: [5]
+                        },
+                        baseCoverage: {
+                            format: 2,
+                            ranges: [{
+                                start: 2,
+                                end: 4,
+                                index: 0
+                            }]
+                        },
+                        markArray: [{
+                            class: 0,
+                            attachmentPoint: {
+                                format: 1,
+                                xCoordinate: -134,
+                                yCoordinate: 812
+                            }
+                        }],
+                        baseArray: [
+                            [{
+                                format: 1,
+                                xCoordinate: -133,
+                                yCoordinate: -500
+                            }],
+                            [{
+                                format: 1,
+                                xCoordinate: 511,
+                                yCoordinate: 91
+                            }]
+                        ]
+                    }]
+            }]);
+        });
+
+        it('should support an extension lookup tables', () => {
+            font.tables.gpos.features = [{
+                tag: 'mark',
+                feature: { featureParams: 0, lookupListIndexes: [1, 2]}
+            }, {
+                tag: 'kern',
+                feature: { featureParams: 0, lookupListIndexes: [0]}
+            }];
+            font.tables.gpos.lookups = [
+                {
+                    lookupType: 9,
+                    lookupFlag: 0,
+                    subtables: [
+                        {
+                            posFormat: 1,
+                            extensionLookupType: 2,
+                            extension: {
+                                posFormat: 1,
+                                coverage: {
+                                    format: 1,
+                                    glyphs: [3]
+                                },
+                                pairSets: [
+                                    [{
+                                        secondGlyph: 5,
+                                        value1: { xAdvance: -91 }
+                                    }]
+                                ]
+                            }
+                        }    
+                    ]
+                },
+                {
+                    lookupType: 9,
+                    lookupFlag: 0,
+                    subtables: [
+                        {
+                            posFormat: 1,
+                            extensionLookupType: 8,
+                            extension: {
+                                posFormat: 1,
+                                coverage: {
+                                    format: 1,
+                                    glyphs: [3]
+                                },
+                                pairSets: [
+                                    [{
+                                        secondGlyph: 5,
+                                        value1: { xAdvance: -91 }
+                                    }]
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                lookupType: 9,
+                lookupFlag: 0,
+                subtables: [
+                    {
+                        posFormat: 1,
+                        extensionLookupType: 4,
+                        extension: {
+                            posFormat: 1,
+                            markCoverage: {
+                                format: 1,
+                                glyphs: [5]
+                            },
+                            baseCoverage: {
+                                format: 2,
+                                ranges: [{
+                                    start: 2,
+                                    end: 4,
+                                    index: 0
+                                }]
+                            },
+                            markArray: [{
+                                class: 0,
+                                attachmentPoint: {
+                                    format: 1,
+                                    xCoordinate: -134,
+                                    yCoordinate: 812
+                                }
+                            }],
+                            baseArray: [
+                                [{
+                                    format: 1,
+                                    xCoordinate: -133,
+                                    yCoordinate: -500
+                                }],
+                                [{
+                                    format: 1,
+                                    xCoordinate: 511,
+                                    yCoordinate: 91
+                                }]
+                            ]
+                        }
+                    }
+                ]
+            }];
+
+            const result = posLayout.getFeaturesLookups(['mark', 'kern']);
+
+            assert.deepStrictEqual(result, [
+                {
+                    feature: 'kern',
+                    lookupType: 2,
+                    lookupFlag: 0,
+                    subtables: [{
+                        posFormat: 1,
+                        coverage: {
+                            format: 1,
+                            glyphs: [3]
+                        },
+                        pairSets: [
+                            [{
+                                secondGlyph: 5,
+                                value1: { xAdvance: -91 }
+                            }]
+                        ]
+                    }]
+                },
+                {
+                    feature: 'mark',
+                    lookupType: 4,
+                    lookupFlag: 0,
+                    subtables: [{
+                        posFormat: 1,
+                        markCoverage: {
+                            format: 1,
+                            glyphs: [5]
+                        },
+                        baseCoverage: {
+                            format: 2,
+                            ranges: [{
+                                start: 2,
+                                end: 4,
+                                index: 0
+                            }]
+                        },
+                        markArray: [{
+                            class: 0,
+                            attachmentPoint: {
+                                format: 1,
+                                xCoordinate: -134,
+                                yCoordinate: 812
+                            }
+                        }],
+                        baseArray: [
+                            [{
+                                format: 1,
+                                xCoordinate: -133,
+                                yCoordinate: -500
+                            }],
+                            [{
+                                format: 1,
+                                xCoordinate: 511,
+                                yCoordinate: 91
+                            }]
+                        ]
+                    }]
+                }]);
+        });
+
+        it('should not return supported an extension lookup tables with not supported lookups', () => {
+            posLayout.supportedFeatures[0].supportedLookups = [8]; // This lookup 8 is not supported 
+            font.tables.gpos.features = [{
+                tag: 'mark',
+                feature: { featureParams: 0, lookupListIndexes: [1, 2]}
+            }, {
+                tag: 'kern',
+                feature: { featureParams: 0, lookupListIndexes: [0]}
+            }];
+            font.tables.gpos.lookups = [
+                {
+                    lookupType: 9,
+                    lookupFlag: 0,
+                    subtables: [
+                        {
+                            posFormat: 1,
+                            extensionLookupType: 2,
+                            extension: {
+                                posFormat: 1,
+                                coverage: {
+                                    format: 1,
+                                    glyphs: [3]
+                                },
+                                pairSets: [
+                                    [{
+                                        secondGlyph: 5,
+                                        value1: { xAdvance: -91 }
+                                    }]
+                                ]
+                            }
+                        }    
+                    ]
+                },
+                {
+                    lookupType: 9,
+                    lookupFlag: 0,
+                    subtables: [
+                        {
+                            posFormat: 1,
+                            extensionLookupType: 8,
+                            extension: {
+                                posFormat: 1,
+                                coverage: {
+                                    format: 1,
+                                    glyphs: [3]
+                                },
+                                pairSets: [
+                                    [{
+                                        secondGlyph: 5,
+                                        value1: { xAdvance: -91 }
+                                    }]
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                lookupType: 9,
+                lookupFlag: 0,
+                subtables: [
+                    {
+                        posFormat: 1,
+                        extensionLookupType: 4,
+                        extension: {
+                            posFormat: 1,
+                            markCoverage: {
+                                format: 1,
+                                glyphs: [5]
+                            },
+                            baseCoverage: {
+                                format: 2,
+                                ranges: [{
+                                    start: 2,
+                                    end: 4,
+                                    index: 0
+                                }]
+                            },
+                            markArray: [{
+                                class: 0,
+                                attachmentPoint: {
+                                    format: 1,
+                                    xCoordinate: -134,
+                                    yCoordinate: 812
+                                }
+                            }],
+                            baseArray: [
+                                [{
+                                    format: 1,
+                                    xCoordinate: -133,
+                                    yCoordinate: -500
+                                }],
+                                [{
+                                    format: 1,
+                                    xCoordinate: 511,
+                                    yCoordinate: 91
+                                }]
+                            ]
+                        }
+                    }
+                ]
+            }];
+
+            const result = posLayout.getFeaturesLookups(['mark', 'kern', 'mkmk']);
+            assert.deepStrictEqual(result, [
+                {
+                    feature: 'mark',
+                    lookupType: 4,
+                    lookupFlag: 0,
+                    subtables: [{
+                        posFormat: 1,
+                        markCoverage: {
+                            format: 1,
+                            glyphs: [5]
+                        },
+                        baseCoverage: {
+                            format: 2,
+                            ranges: [{
+                                start: 2,
+                                end: 4,
+                                index: 0
+                            }]
+                        },
+                        markArray: [{
+                            class: 0,
+                            attachmentPoint: {
+                                format: 1,
+                                xCoordinate: -134,
+                                yCoordinate: 812
+                            }
+                        }],
+                        baseArray: [
+                            [{
+                                format: 1,
+                                xCoordinate: -133,
+                                yCoordinate: -500
+                            }],
+                            [{
+                                format: 1,
+                                xCoordinate: 511,
+                                yCoordinate: 91
+                            }]
+                        ]
+                    }]
+            }]);
+        });
+
     });
 });

--- a/test/layout.js
+++ b/test/layout.js
@@ -386,7 +386,7 @@ describe('layout.js', function() {
                             }]
                         ]
                     }]
-            }]);
+                }]);
         });
 
         it('should support an extension lookup tables', () => {
@@ -418,7 +418,7 @@ describe('layout.js', function() {
                                     }]
                                 ]
                             }
-                        }    
+                        }
                     ]
                 },
                 {
@@ -554,7 +554,7 @@ describe('layout.js', function() {
         });
 
         it('should not return supported an extension lookup tables with not supported lookups', () => {
-            posLayout.supportedFeatures[0].supportedLookups = [8]; // This lookup 8 is not supported 
+            posLayout.supportedFeatures[0].supportedLookups = [8]; // This lookup 8 is not supported
             font.tables.gpos.features = [{
                 tag: 'mark',
                 feature: { featureParams: 0, lookupListIndexes: [1, 2]}
@@ -583,7 +583,7 @@ describe('layout.js', function() {
                                     }]
                                 ]
                             }
-                        }    
+                        }
                     ]
                 },
                 {
@@ -696,7 +696,7 @@ describe('layout.js', function() {
                             }]
                         ]
                     }]
-            }]);
+                }]);
         });
 
     });

--- a/test/parse.js
+++ b/test/parse.js
@@ -112,7 +112,7 @@ describe('parse.js', function() {
             ' 0000  000E ' + // mark1 class and its anchor offset
             ' 0001  001A ' + // mark2 class and its anchor offset
             ' 0000  0014 ' + // mark3 class and its anchor offset
-            ' 0001 00BD 012D ' +   
+            ' 0001 00BD 012D ' +
             ' 0001 00DD 012E ' +
             ' 0002 00DF FED1 0001';
 
@@ -132,7 +132,7 @@ describe('parse.js', function() {
                     yCoordinate: -303,
                     anchorPoint: 1
                 }
-            },{
+            }, {
                 class: 0,
                 attachmentPoint: {
                     format: 1,
@@ -151,7 +151,7 @@ describe('parse.js', function() {
             const data = '0002 ' + // baseCount
             ' 000E 0014 001E' + // baseRecord1 anchor offsets foreach class anchor point
             ' 0014 000E 001E' + // baseRecord2 anchor offsets foreach class anchor point
-            ' 0001 00BD 012D ' +    // 
+            ' 0001 00BD 012D ' +    //
             ' 0003 00BD 012D 0000 0000 ' +
             ' 0002 00DF FED1 0001';
 
@@ -178,7 +178,7 @@ describe('parse.js', function() {
                     }
                 ],
                 [
-                    
+
                     {
                         format: 3,
                         xCoordinate: 189,
@@ -207,7 +207,7 @@ describe('parse.js', function() {
 
     describe('parseAnchorPoint', () => {
         it('should parse a AnchorTableFormat1 table', () => {
-            const data =' 0001 00BD 012D';
+            const data = ' 0001 00BD 012D';
             const p = new Parser(unhex(data), 0);
             assert.deepEqual(p.parseAnchorPoint(), {
                 format: 1,
@@ -217,7 +217,7 @@ describe('parse.js', function() {
         });
 
         it('should parse a AnchorTableFormat2 table', () => {
-            const data =' 0002 00DF FED1 0003';
+            const data = ' 0002 00DF FED1 0003';
             const p = new Parser(unhex(data), 0);
             assert.deepEqual(p.parseAnchorPoint(), {
                 format: 2,
@@ -228,7 +228,7 @@ describe('parse.js', function() {
         });
 
         it('should parse a AnchorTableFormat3 table', () => {
-            const data =' 0003 00BD 012D 0000 0000';
+            const data = ' 0003 00BD 012D 0000 0000';
             const p = new Parser(unhex(data), 0);
             assert.deepEqual(p.parseAnchorPoint(), {
                 format: 3,

--- a/test/parse.js
+++ b/test/parse.js
@@ -106,6 +106,140 @@ describe('parse.js', function() {
         });
     });
 
+    describe('parseMarkArray', () => {
+        it('should parse a Mark Array table', () => {
+            const data = '0003 ' + // marksCount
+            ' 0000  000E ' + // mark1 class and its anchor offset
+            ' 0001  001A ' + // mark2 class and its anchor offset
+            ' 0000  0014 ' + // mark3 class and its anchor offset
+            ' 0001 00BD 012D ' +   
+            ' 0001 00DD 012E ' +
+            ' 0002 00DF FED1 0001';
+
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseMarkArray(), [{
+                class: 0,
+                attachmentPoint: {
+                    format: 1,
+                    xCoordinate: 189,
+                    yCoordinate: 301
+                }
+            }, {
+                class: 1,
+                attachmentPoint: {
+                    format: 2,
+                    xCoordinate: 223,
+                    yCoordinate: -303,
+                    anchorPoint: 1
+                }
+            },{
+                class: 0,
+                attachmentPoint: {
+                    format: 1,
+                    xCoordinate: 221,
+                    yCoordinate: 302,
+
+                }
+            }]);
+
+            assert.equal(p.relativeOffset, 14);
+        });
+    });
+
+    describe('parseBaseArray', () => {
+        it('should parse a Base Array table', () => {
+            const data = '0002 ' + // baseCount
+            ' 000E 0014 001E' + // baseRecord1 anchor offsets foreach class anchor point
+            ' 0014 000E 001E' + // baseRecord2 anchor offsets foreach class anchor point
+            ' 0001 00BD 012D ' +    // 
+            ' 0003 00BD 012D 0000 0000 ' +
+            ' 0002 00DF FED1 0001';
+
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseBaseArray(3), [
+                [
+                    {
+                        format: 1,
+                        xCoordinate: 189,
+                        yCoordinate: 301
+                    },
+                    {
+                        format: 3,
+                        xCoordinate: 189,
+                        yCoordinate: 301,
+                        xDevice: 0,
+                        yDevice: 0
+                    },
+                    {
+                        format: 2,
+                        xCoordinate: 223,
+                        yCoordinate: -303,
+                        anchorPoint: 1
+                    }
+                ],
+                [
+                    
+                    {
+                        format: 3,
+                        xCoordinate: 189,
+                        yCoordinate: 301,
+                        xDevice: 0,
+                        yDevice: 0
+                    },
+                    {
+                        format: 1,
+                        xCoordinate: 189,
+                        yCoordinate: 301
+                    },
+                    {
+                        format: 2,
+                        xCoordinate: 223,
+                        yCoordinate: -303,
+                        anchorPoint: 1
+                    }
+                ]
+            ]);
+
+            assert.equal(p.relativeOffset, 14);
+
+        });
+    });
+
+    describe('parseAnchorPoint', () => {
+        it('should parse a AnchorTableFormat1 table', () => {
+            const data =' 0001 00BD 012D';
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseAnchorPoint(), {
+                format: 1,
+                xCoordinate: 189,
+                yCoordinate: 301,
+            });
+        });
+
+        it('should parse a AnchorTableFormat2 table', () => {
+            const data =' 0002 00DF FED1 0003';
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseAnchorPoint(), {
+                format: 2,
+                xCoordinate: 223,
+                yCoordinate: -303,
+                anchorPoint: 3
+            });
+        });
+
+        it('should parse a AnchorTableFormat3 table', () => {
+            const data =' 0003 00BD 012D 0000 0000';
+            const p = new Parser(unhex(data), 0);
+            assert.deepEqual(p.parseAnchorPoint(), {
+                format: 3,
+                xCoordinate: 189,
+                yCoordinate: 301,
+                xDevice: 0,
+                yDevice: 0
+            });
+        });
+    });
+
     describe('parseCoverage', function() {
         it('should parse a CoverageFormat1 table', function() {
             // https://www.microsoft.com/typography/OTSPEC/chapter2.htm Example 5

--- a/test/tables/gpos.js
+++ b/test/tables/gpos.js
@@ -138,4 +138,253 @@ describe('tables/gpos.js', function() {
             ]
         });
     });
+
+    //// Lookup type 4 ////////////////////////////////////////////////////////
+    it('can parse lookup4 MarkBasePosFormat1', () => {
+
+        const data = 
+            ` 0001` + // MarkMarkPosFormat1
+            ` 000C` + // markCoverageOffset
+            ` 0016` + // baseCoverageOffset
+            ` 0002` + // markClassCount
+            ` 001C` + // markArrayOffset
+            ` 0038` + // baseArrayOffset
+            ` 0002 0001 0045 0046 0000` + 
+            ` 0001 0001 0047` +
+            ` 0002  0000  000A   0001  0016  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1` + 
+            ` 0001    0006 000C  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1` + 
+            ``;
+
+        const expectedResult = {
+            posFormat: 1,
+            markCoverage: {
+                format: 2,
+                ranges: [
+                    { start: 0x45, end: 0x46, index: 0 }
+                ]
+            },
+            baseCoverage: {
+                glyphs: [71],
+                format: 1
+            },
+            markArray: [{
+                class: 0,
+                attachmentPoint: {
+                    format: 1,
+                    xCoordinate: 189,
+                    yCoordinate: 301
+                }
+            }, {
+                class: 1,
+                attachmentPoint: {
+                    format: 1,
+                    xCoordinate: 223,
+                    yCoordinate: -303
+                }
+            }],
+            baseArray: [
+                [{
+                    format: 1,
+                    xCoordinate: 189,
+                    yCoordinate: 301
+                }, 
+                {
+                    format: 1,
+                    xCoordinate: 221,
+                    yCoordinate: 302
+                }]
+            ]
+        };
+
+        assert.deepEqual(parseLookup(4, data), expectedResult);
+    });
+
+    //// Lookup type 9 ////////////////////////////////////////////////////////
+    describe('lookup9 ExtensionPosFormat1', () => {
+
+        it('should return an error message for unsupported lookup type: 3', () => {
+            const UnsupportedLookupType = '0003';
+            const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
+            assert.deepEqual(parseLookup(9, data), { 
+                posFormat: 1,
+                extensionLookupType: 3,
+                extension: { error: 'GPOS Lookup 3 not supported' }
+            });
+        });
+
+        it('should return an error message for unsupported lookup type: 5', () => {
+            const UnsupportedLookupType = '0005';
+            const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
+            assert.deepEqual(parseLookup(9, data), { 
+                posFormat: 1,
+                extensionLookupType: 5,
+                extension: { error: 'GPOS Lookup 5 not supported' }
+            });
+        });
+
+        it('should return an error message for unsupported lookup type: 6', () => {
+            const UnsupportedLookupType = '0006';
+            const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
+            assert.deepEqual(parseLookup(9, data), { 
+                posFormat: 1,
+                extensionLookupType: 6,
+                extension: { error: 'GPOS Lookup 6 not supported' }
+            });
+        });
+
+        it('should return an error message for unsupported lookup type: 7', () => {
+            const UnsupportedLookupType = '0007';
+            const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
+            assert.deepEqual(parseLookup(9, data), { 
+                posFormat: 1,
+                extensionLookupType: 7,
+                extension: { error: 'GPOS Lookup 7 not supported' }
+            });
+        });
+
+        it('should return an error message for unsupported lookup type: 8', () => {
+            const UnsupportedLookupType = '0008';
+            const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
+            assert.deepEqual(parseLookup(9, data), { 
+                posFormat: 1,
+                extensionLookupType: 8,
+                extension: { error: 'GPOS Lookup 8 not supported' }
+            });
+        });
+
+        it('can parse lookup1 extension table', () => {
+
+            const SinglePosFormat1data = '0001 0008 0002   FFB0 0002 0001   01B3 01BC 0000';
+            const data = 
+                ` 0001` +
+                ` 0001` + // extensionLookupType
+                ` 00000008` + // extensionLookupTableOffset
+                ` ${SinglePosFormat1data}` +
+                ``;
+
+            const expectedResult = {
+                posFormat: 1,
+                extensionLookupType: 1,
+                extension: {
+                    posFormat: 1,
+                    coverage: {
+                        format: 2,
+                        ranges: [{ start: 0x1b3, end: 0x1bc, index: 0 }]
+                    },
+                    value: { yPlacement: -80 }
+                }
+            };
+
+            assert.deepEqual(parseLookup(9, data), expectedResult);
+        }); 
+        
+        it('can parse lookup2 extension table', () => {
+
+            const lookup2Data = '0002 0018 0004 0000 0022 0032 0002 0002 0000 0000 0000 FFCE   0001 0003 0046 0047 0049   0002 0002 0046 0047 0001 0049 0049 0001   0002 0001 006A 006B 0001';
+            const data = 
+                ` 0001` +
+                ` 0002` + // extensionLookupType
+                ` 00000008` + // extensionLookupTableOffset
+                ` ${lookup2Data}` +
+                ``;
+
+            const expectedResult = {
+                posFormat: 1,
+                extensionLookupType: 2,
+                extension: {
+                    posFormat: 2,
+                    coverage: {
+                        format: 1,
+                        glyphs: [0x46, 0x47, 0x49]
+                    },
+                    valueFormat1: 4,
+                    valueFormat2: 0,
+                    classDef1: {
+                        format: 2,
+                        ranges: [
+                            { start: 0x46, end: 0x47, classId: 1 },
+                            { start: 0x49, end: 0x49, classId: 1 }
+                        ]
+                    },
+                    classDef2: {
+                        format: 2,
+                        ranges: [
+                            { start: 0x6a, end: 0x6b, classId: 1 }
+                        ]
+                    },
+                    class1Count: 2,
+                    class2Count: 2,
+                    classRecords: [
+                        [
+                            { value1: { xAdvance: 0 }, value2: undefined },
+                            { value1: { xAdvance: 0 }, value2: undefined }
+                        ],
+                        [
+                            { value1: { xAdvance: 0 }, value2: undefined },
+                            { value1: { xAdvance: -50 }, value2: undefined }
+                        ]
+                    ]
+                }
+            };
+
+            assert.deepEqual(parseLookup(9, data), expectedResult);
+        }); 
+
+        it('can parse lookup4 extension table', () => {
+
+            const MarkBasePosFormat1 = ' 0001 000C 0016 0002 001C 0038 0002 0001 0045 0046 0000 0001 0001 0047 0002  0000  000A   0001  0016  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1 0001    0006 000C  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1';
+            const data = 
+                ` 0001` +
+                ` 0004` + // extensionLookupType
+                ` 00000008` + // extensionLookupTableOffset
+                ` ${MarkBasePosFormat1}` +
+                ``;
+
+            const expectedResult = {
+                posFormat: 1,
+                extensionLookupType: 4,
+                extension: {
+                    posFormat: 1,
+                    markCoverage: {
+                        format: 2,
+                        ranges: [
+                            { start: 0x45, end: 0x46, index: 0 }
+                        ]
+                    },
+                    baseCoverage: {
+                        glyphs: [71],
+                        format: 1
+                    },
+                    markArray: [{
+                        class: 0,
+                        attachmentPoint: {
+                            format: 1,
+                            xCoordinate: 189,
+                            yCoordinate: 301
+                        }
+                    }, {
+                        class: 1,
+                        attachmentPoint: {
+                            format: 1,
+                            xCoordinate: 223,
+                            yCoordinate: -303
+                        }
+                    }],
+                    baseArray: [ 
+                        [{
+                            format: 1,
+                            xCoordinate: 189,
+                            yCoordinate: 301
+                        }, {
+                            format: 1,
+                            xCoordinate: 221,
+                            yCoordinate: 302
+                        }]
+                    ]
+                }
+            };
+
+            assert.deepEqual(parseLookup(9, data), expectedResult);
+        });
+    });
 });

--- a/test/tables/gpos.js
+++ b/test/tables/gpos.js
@@ -142,17 +142,17 @@ describe('tables/gpos.js', function() {
     //// Lookup type 4 ////////////////////////////////////////////////////////
     it('can parse lookup4 MarkBasePosFormat1', () => {
 
-        const data = 
+        const data =
             ` 0001` + // MarkMarkPosFormat1
             ` 000C` + // markCoverageOffset
             ` 0016` + // baseCoverageOffset
             ` 0002` + // markClassCount
             ` 001C` + // markArrayOffset
             ` 0038` + // baseArrayOffset
-            ` 0002 0001 0045 0046 0000` + 
+            ` 0002 0001 0045 0046 0000` +
             ` 0001 0001 0047` +
-            ` 0002  0000  000A   0001  0016  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1` + 
-            ` 0001    0006 000C  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1` + 
+            ` 0002  0000  000A   0001  0016  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1` +
+            ` 0001    0006 000C  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1` +
             ``;
 
         const expectedResult = {
@@ -187,7 +187,7 @@ describe('tables/gpos.js', function() {
                     format: 1,
                     xCoordinate: 189,
                     yCoordinate: 301
-                }, 
+                },
                 {
                     format: 1,
                     xCoordinate: 221,
@@ -205,7 +205,7 @@ describe('tables/gpos.js', function() {
         it('should return an error message for unsupported lookup type: 3', () => {
             const UnsupportedLookupType = '0003';
             const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
-            assert.deepEqual(parseLookup(9, data), { 
+            assert.deepEqual(parseLookup(9, data), {
                 posFormat: 1,
                 extensionLookupType: 3,
                 extension: { error: 'GPOS Lookup 3 not supported' }
@@ -215,7 +215,7 @@ describe('tables/gpos.js', function() {
         it('should return an error message for unsupported lookup type: 5', () => {
             const UnsupportedLookupType = '0005';
             const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
-            assert.deepEqual(parseLookup(9, data), { 
+            assert.deepEqual(parseLookup(9, data), {
                 posFormat: 1,
                 extensionLookupType: 5,
                 extension: { error: 'GPOS Lookup 5 not supported' }
@@ -225,7 +225,7 @@ describe('tables/gpos.js', function() {
         it('should return an error message for unsupported lookup type: 6', () => {
             const UnsupportedLookupType = '0006';
             const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
-            assert.deepEqual(parseLookup(9, data), { 
+            assert.deepEqual(parseLookup(9, data), {
                 posFormat: 1,
                 extensionLookupType: 6,
                 extension: { error: 'GPOS Lookup 6 not supported' }
@@ -235,7 +235,7 @@ describe('tables/gpos.js', function() {
         it('should return an error message for unsupported lookup type: 7', () => {
             const UnsupportedLookupType = '0007';
             const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
-            assert.deepEqual(parseLookup(9, data), { 
+            assert.deepEqual(parseLookup(9, data), {
                 posFormat: 1,
                 extensionLookupType: 7,
                 extension: { error: 'GPOS Lookup 7 not supported' }
@@ -245,7 +245,7 @@ describe('tables/gpos.js', function() {
         it('should return an error message for unsupported lookup type: 8', () => {
             const UnsupportedLookupType = '0008';
             const data = `0001 ${UnsupportedLookupType} 00000008 0001`;
-            assert.deepEqual(parseLookup(9, data), { 
+            assert.deepEqual(parseLookup(9, data), {
                 posFormat: 1,
                 extensionLookupType: 8,
                 extension: { error: 'GPOS Lookup 8 not supported' }
@@ -255,7 +255,7 @@ describe('tables/gpos.js', function() {
         it('can parse lookup1 extension table', () => {
 
             const SinglePosFormat1data = '0001 0008 0002   FFB0 0002 0001   01B3 01BC 0000';
-            const data = 
+            const data =
                 ` 0001` +
                 ` 0001` + // extensionLookupType
                 ` 00000008` + // extensionLookupTableOffset
@@ -276,12 +276,12 @@ describe('tables/gpos.js', function() {
             };
 
             assert.deepEqual(parseLookup(9, data), expectedResult);
-        }); 
-        
+        });
+
         it('can parse lookup2 extension table', () => {
 
             const lookup2Data = '0002 0018 0004 0000 0022 0032 0002 0002 0000 0000 0000 FFCE   0001 0003 0046 0047 0049   0002 0002 0046 0047 0001 0049 0049 0001   0002 0001 006A 006B 0001';
-            const data = 
+            const data =
                 ` 0001` +
                 ` 0002` + // extensionLookupType
                 ` 00000008` + // extensionLookupTableOffset
@@ -328,12 +328,14 @@ describe('tables/gpos.js', function() {
             };
 
             assert.deepEqual(parseLookup(9, data), expectedResult);
-        }); 
+        });
 
         it('can parse lookup4 extension table', () => {
 
-            const MarkBasePosFormat1 = ' 0001 000C 0016 0002 001C 0038 0002 0001 0045 0046 0000 0001 0001 0047 0002  0000  000A   0001  0016  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1 0001    0006 000C  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1';
-            const data = 
+            const MarkBasePosFormat1 = ' 0001 000C 0016 0002 001C 0038 0002 0001 0045 0046 0000 0001 0001 0047 0002 ' +
+            ' 0000  000A   0001  0016  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1 0001 ' +
+            ' 0006 000C  0001 00BD 012D 0001 00DD 012E 0001 00DF FED1';
+            const data =
                 ` 0001` +
                 ` 0004` + // extensionLookupType
                 ` 00000008` + // extensionLookupTableOffset
@@ -370,7 +372,7 @@ describe('tables/gpos.js', function() {
                             yCoordinate: -303
                         }
                     }],
-                    baseArray: [ 
+                    baseArray: [
                         [{
                             format: 1,
                             xCoordinate: 189,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added support for Mark to Base Attachment Positioning (for the DFLT script). Feature is enabled by default because it is a part of a proper glyphs positioning. Includes capabilities implementation for the corresponding parsers (GPOS lookup 4 & 9)

Followed the current solution's convention to introduce new features within the font & layout implementation.

- added GPOS `LookupType 4` parser for `MarkBasePosFormat1` support
- added GPOS `LookupType 9` parser for Extension Positioning `SubtableFormat1` support
- introduced the union lookup feature (`getFeaturesLookups`) for the layout to meet the OT specs
- tests coverage for kerning and positioning features
- tests coverage for all supported and not supported lookups of GPOS

**TODO**: Add support for non DFLT scripts for `MARK` (`src/font.js:344`)
**TODO**: Add a support device offsets for anchor table format 3 (`src/parse.js:515`)
**TODO**: Add MarkToMark Attachment positioning (lookup type 6) functionality.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fonts like Mandarin or Thai to successfully render text with all glyphs (sometimes 3+) representing characters like `ปั` or `ริ่`
requiring the `LookupType 4` for mark to base attachment positioning to do it properly. 

[Extension subtables support](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning) is **required** to support the subtables that exceeds the 16-bit limits of the various other offsets in the GPOS table - that genuinely are being used eg. for the [Apples SF Pro fonts](https://developer.apple.com/fonts/) and many others.

The union lookup feature (`getFeaturesLookups`) was required actually to meet the [OpenType specification](https://learn.microsoft.com/en-us/typography/opentype/otspec191alpha/chapter2#lookup-list-table) which guarantees that all enabled features will be processed in a valid order. 
> the list of lookups is the union of lookups referenced by all of those features, and these are all processed in their lookup list order.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added tests coverage to the `test/parser.js` and `test/tables/gpos.js` including new binary data and testing:
- the [Lookup Type 4: Mark-to-Base Attachment Positioning Subtable specification](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-4-mark-to-base-attachment-positioning-subtable)
- the [LookupType 9: Extension Positioning](https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookuptype-9-extension-positioning)

These lookups uses existing structures like coverage tables, and were tested agains different formats.  Extension positioning lookup was tested agains all currently supported and not supported subtable parsers. 

Added tests coverage to the `test/layout.js` to test the method for union lookups (`getFeaturesLookups`).
Added tests coverage for glyph positioning tests in the `test/font.js` including:
- Kerning feature support with kerning table and lookup table support
- `options.kerning` and  `options.features.kern` testing 
- Mark To Base Attachment feature support to work with kern features
- `options.features.mark` testing

Moreover there were many test conducted for the rendered content using `latn` and `arab` fonts.

## Screenshots (if appropriate):

BEFORE (INVALID glyphs pos):
![image](https://user-images.githubusercontent.com/102729629/216976249-278734ce-ee78-491c-a19c-8208e730d516.png)

AFTER (FIXED):
![image](https://user-images.githubusercontent.com/102729629/216973120-aad3661c-f59f-4139-a3f3-82bfb9df960d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I did `npm run test` and all tests passed green (including code styling checks).
- [x] I have added tests to cover my changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the **README** accordingly.
- [x] I have read the **CONTRIBUTING** document.
